### PR TITLE
[graph] add a ReversedDirected adapter

### DIFF
--- a/cargo-guppy-lib/src/graph/mod.rs
+++ b/cargo-guppy-lib/src/graph/mod.rs
@@ -10,7 +10,8 @@ use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 
 mod build;
-mod visit;
+// `visit` is exposed to the rest of the crate for testing.
+pub(crate) mod visit;
 
 /// A graph of packages extracted from a metadata.
 #[derive(Clone, Debug)]

--- a/cargo-guppy-lib/src/graph/visit.rs
+++ b/cargo-guppy-lib/src/graph/visit.rs
@@ -1,1 +1,0 @@
-pub mod walk;

--- a/cargo-guppy-lib/src/graph/visit/mod.rs
+++ b/cargo-guppy-lib/src/graph/visit/mod.rs
@@ -1,0 +1,2 @@
+pub mod reversed;
+pub mod walk;

--- a/cargo-guppy-lib/src/graph/visit/reversed.rs
+++ b/cargo-guppy-lib/src/graph/visit/reversed.rs
@@ -1,0 +1,194 @@
+use petgraph::prelude::*;
+use petgraph::visit::{
+    Data, GraphBase, GraphRef, IntoEdgeReferences, IntoEdges, IntoEdgesDirected, IntoNeighbors,
+    IntoNeighborsDirected, IntoNodeIdentifiers, IntoNodeReferences, Visitable,
+};
+
+/// `ReversedDirected` is a reversing adapter for directed graphs.
+///
+/// This is similar to `petgraph::visit::Reversed`, except with `IntoEdges` and `IntoEdgesDirected`
+/// implemented as well. Unfortunately, due to an inconsistency between undirected and directed
+/// graphs, these trait impls don't behave correctly for undirected graphs.
+///
+/// For more details about the issue, see the
+/// [petgraph bugtracker](https://github.com/petgraph/petgraph/issues/292).
+#[derive(Copy, Clone, Debug)]
+pub struct ReversedDirected<G>(G);
+
+impl<G> ReversedDirected<G> {
+    #[allow(dead_code)]
+    pub fn new(graph: G) -> Self {
+        ReversedDirected(graph)
+    }
+}
+
+impl<G: GraphBase> GraphBase for ReversedDirected<G> {
+    type NodeId = G::NodeId;
+    type EdgeId = G::EdgeId;
+}
+
+impl<G: GraphRef> GraphRef for ReversedDirected<G> {}
+
+impl<G: Data> Data for ReversedDirected<G>
+where
+    G: Data,
+{
+    type NodeWeight = G::NodeWeight;
+    type EdgeWeight = G::EdgeWeight;
+}
+
+// ---
+// New trait impls
+// ---
+
+impl<G> IntoEdges for ReversedDirected<G>
+where
+    G: IntoEdgesDirected,
+{
+    type Edges = ReversedEdges<G::EdgesDirected>;
+    fn edges(self, a: Self::NodeId) -> Self::Edges {
+        ReversedEdges {
+            iter: self.0.edges_directed(a, Incoming),
+        }
+    }
+}
+
+impl<G> IntoEdgesDirected for ReversedDirected<G>
+where
+    G: IntoEdgesDirected,
+{
+    type EdgesDirected = ReversedEdges<G::EdgesDirected>;
+    fn edges_directed(self, a: Self::NodeId, dir: Direction) -> Self::Edges {
+        ReversedEdges {
+            iter: self.0.edges_directed(a, dir.opposite()),
+        }
+    }
+}
+
+/// A reversed edges iterator.
+pub struct ReversedEdges<I> {
+    iter: I,
+}
+
+impl<I> Iterator for ReversedEdges<I>
+where
+    I: Iterator,
+    I::Item: EdgeRef,
+{
+    type Item = ReversedEdgeReference<I::Item>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(ReversedEdgeReference)
+    }
+}
+
+// ---
+// Other impls, copied from petgraph
+// ---
+
+impl<G> IntoNeighbors for ReversedDirected<G>
+where
+    G: IntoNeighborsDirected,
+{
+    type Neighbors = G::NeighborsDirected;
+    fn neighbors(self, n: G::NodeId) -> G::NeighborsDirected {
+        self.0.neighbors_directed(n, Incoming)
+    }
+}
+
+impl<G> IntoNeighborsDirected for ReversedDirected<G>
+where
+    G: IntoNeighborsDirected,
+{
+    type NeighborsDirected = G::NeighborsDirected;
+    fn neighbors_directed(self, n: G::NodeId, d: Direction) -> G::NeighborsDirected {
+        self.0.neighbors_directed(n, d.opposite())
+    }
+}
+
+impl<G: Visitable> Visitable for ReversedDirected<G> {
+    type Map = G::Map;
+    fn visit_map(&self) -> G::Map {
+        self.0.visit_map()
+    }
+    fn reset_map(&self, map: &mut Self::Map) {
+        self.0.reset_map(map);
+    }
+}
+
+/// A reversed edge reference.
+#[derive(Copy, Clone, Debug)]
+pub struct ReversedEdgeReference<R>(R);
+
+/// An edge reference
+impl<R> EdgeRef for ReversedEdgeReference<R>
+where
+    R: EdgeRef,
+{
+    type NodeId = R::NodeId;
+    type EdgeId = R::EdgeId;
+    type Weight = R::Weight;
+    fn source(&self) -> Self::NodeId {
+        self.0.target()
+    }
+    fn target(&self) -> Self::NodeId {
+        self.0.source()
+    }
+    fn weight(&self) -> &Self::Weight {
+        self.0.weight()
+    }
+    fn id(&self) -> Self::EdgeId {
+        self.0.id()
+    }
+}
+
+impl<G> IntoEdgeReferences for ReversedDirected<G>
+where
+    G: IntoEdgeReferences,
+{
+    type EdgeRef = ReversedEdgeReference<G::EdgeRef>;
+    type EdgeReferences = ReversedEdgeReferences<G::EdgeReferences>;
+    fn edge_references(self) -> Self::EdgeReferences {
+        ReversedEdgeReferences {
+            iter: self.0.edge_references(),
+        }
+    }
+}
+
+/// A reversed edge references iterator.
+pub struct ReversedEdgeReferences<I> {
+    iter: I,
+}
+
+impl<I> Iterator for ReversedEdgeReferences<I>
+where
+    I: Iterator,
+    I::Item: EdgeRef,
+{
+    type Item = ReversedEdgeReference<I::Item>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(ReversedEdgeReference)
+    }
+}
+
+impl<G> IntoNodeIdentifiers for ReversedDirected<G>
+where
+    G: IntoNodeIdentifiers,
+{
+    type NodeIdentifiers = G::NodeIdentifiers;
+    fn node_identifiers(self) -> Self::NodeIdentifiers {
+        self.0.node_identifiers()
+    }
+}
+
+impl<G> IntoNodeReferences for ReversedDirected<G>
+where
+    G: IntoNodeReferences,
+{
+    type NodeRef = G::NodeRef;
+    type NodeReferences = G::NodeReferences;
+    fn node_references(self) -> Self::NodeReferences {
+        self.0.node_references()
+    }
+}
+
+// This is incomplete -- feel free to add more forwarding impls as necessary!

--- a/cargo-guppy-lib/src/unit_tests/mod.rs
+++ b/cargo-guppy-lib/src/unit_tests/mod.rs
@@ -1,2 +1,3 @@
 mod fixtures;
 mod graph_tests;
+mod reversed_tests;

--- a/cargo-guppy-lib/src/unit_tests/reversed_tests.rs
+++ b/cargo-guppy-lib/src/unit_tests/reversed_tests.rs
@@ -1,0 +1,96 @@
+//! These tests are for the additional functionality added to ReversedDirected. The base
+//! implementation is the same as `petgraph::visit::Reversed` so it is not tested.
+
+use crate::graph::visit::reversed::ReversedDirected;
+use petgraph::prelude::*;
+use petgraph::visit::{IntoEdges, IntoEdgesDirected};
+
+#[test]
+fn reversed_directed_edge_impls() {
+    // Directed acyclic graph:
+    //
+    // A --> B
+    // |     |
+    // v     v
+    // C --> D
+
+    let mut graph = Graph::new();
+    let a = graph.add_node("A");
+    let b = graph.add_node("B");
+    let c = graph.add_node("C");
+    let d = graph.add_node("D");
+    graph.add_edge(a, b, ());
+    graph.add_edge(a, c, ());
+    graph.add_edge(b, d, ());
+    graph.add_edge(c, d, ());
+
+    // The reversed graph is:
+    //
+    // A <-- B
+    // ^     ^
+    // |     |
+    // C <-- D
+    let reversed = ReversedDirected::new(&graph);
+
+    for source in vec![a, b, c, d] {
+        for edge in reversed.edges(source) {
+            assert_eq!(edge.source(), source, "edge sources should be correct");
+        }
+        for edge in reversed.edges_directed(source, Outgoing) {
+            assert_eq!(
+                edge.source(),
+                source,
+                "outgoing edge sources should be correct"
+            );
+        }
+        for edge in reversed.edges_directed(source, Incoming) {
+            assert_eq!(
+                edge.target(),
+                source,
+                "incoming edge targets should be correct"
+            );
+        }
+
+        // Check that outgoing edges in the reversed graph are the same as incoming edges in the
+        // normal graph, with source and target reversed.
+        let mut outgoing: Vec<_> = graph
+            .edges_directed(source, Outgoing)
+            .map(source_target)
+            .collect();
+        outgoing.sort();
+        let mut reversed_incoming: Vec<_> = reversed
+            .edges_directed(source, Incoming)
+            .map(target_source)
+            .collect();
+        reversed_incoming.sort();
+
+        assert_eq!(outgoing, reversed_incoming, "outgoing = reversed incoming");
+
+        // Check that incoming edges in the reversed graph are the same as outgoing edges in the
+        // normal graph, with directions reversed.
+        let mut incoming: Vec<_> = graph
+            .edges_directed(source, Incoming)
+            .map(source_target)
+            .collect();
+        incoming.sort();
+        let mut reversed_outgoing: Vec<_> = reversed
+            .edges_directed(source, Outgoing)
+            .map(target_source)
+            .collect();
+        reversed_outgoing.sort();
+        // `edges` should behave the same way as `edges_directed` with `Outgoing`.
+        let mut reversed_edges: Vec<_> = reversed.edges(source).map(target_source).collect();
+        reversed_edges.sort();
+
+        assert_eq!(incoming, reversed_outgoing, "incoming = reversed outgoing");
+        assert_eq!(incoming, reversed_edges, "incoming = reversed edges");
+    }
+}
+
+fn source_target<ER: EdgeRef>(edge: ER) -> (ER::NodeId, ER::NodeId) {
+    (edge.source(), edge.target())
+}
+
+fn target_source<ER: EdgeRef>(edge: ER) -> (ER::NodeId, ER::NodeId) {
+    (edge.target(), edge.source())
+}


### PR DESCRIPTION
This is similar to `petgraph::visit::Reversed`, except that it has implementations for `IntoEdges` and `IntoEdgesDirected`. This adapter will be used in upcoming patches.

Due to an inconsistency in `petgraph` (https://github.com/petgraph/petgraph/issues/292), this adapter can only be used for directed graphs. Hopefully a future version of `petgraph` will fix this inconsistency.