### PR TITLE
[graph] use a more principled way to flip indexes in reversed graphs

### DIFF
--- a/cargo-guppy-lib/src/graph/mod.rs
+++ b/cargo-guppy-lib/src/graph/mod.rs
@@ -1,5 +1,8 @@
 use crate::errors::Error;
-use crate::graph::visit::{reversed::ReversedDirected, walk::EdgeDfs};
+use crate::graph::visit::{
+    reversed::{ReverseFlip, ReversedDirected},
+    walk::EdgeDfs,
+};
 use cargo_metadata::{Dependency, DependencyKind, Metadata, MetadataCommand, NodeDep, PackageId};
 use either::Either;
 use lazy_static::lazy_static;
@@ -367,18 +370,26 @@ impl PackageGraph {
         package_ids: impl IntoIterator<Item = &'a PackageId>,
         direction: DependencyDirection,
     ) -> Result<impl Iterator<Item = DependencyLink<'g>> + 'g, Error> {
+        // This could be written as calls to transitive_dep_links instead of the internal _impl
+        // method, but as of Rust 1.39 that causes the lifetime analyzer to fail with:
+        //
+        // error[E0309]: the parameter type `impl IntoIterator<Item = &'a PackageId>` may not live long enough
+        // help: consider adding an explicit lifetime bound  `'g` to `impl IntoIterator<Item = &'a PackageId>`...
+        // |
+        // |         package_ids: impl IntoIterator<Item = &'a PackageId> + 'g,
+        // |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        //
+        // That bound shouldn't be necessary. Could it be an issue with rustc's lifetime analyzer?
+        // XXX follow up about this.
+
         let node_idxs: Vec<_> = self.node_idxs(package_ids)?;
         match direction {
-            DependencyDirection::Forward => Ok(Either::Left(self.transitive_dep_links_impl(
-                node_idxs,
-                &self.dep_graph,
-                direction,
-            ))),
-            DependencyDirection::Reverse => Ok(Either::Right(self.transitive_dep_links_impl(
-                node_idxs,
-                ReversedDirected::new(&self.dep_graph),
-                direction,
-            ))),
+            DependencyDirection::Forward => Ok(Either::Left(
+                self.transitive_dep_links_impl(node_idxs, &self.dep_graph),
+            )),
+            DependencyDirection::Reverse => Ok(Either::Right(
+                self.transitive_dep_links_impl(node_idxs, ReversedDirected::new(&self.dep_graph)),
+            )),
         }
     }
 
@@ -393,13 +404,7 @@ impl PackageGraph {
         package_ids: impl IntoIterator<Item = &'a PackageId>,
     ) -> Result<impl Iterator<Item = DependencyLink<'g>> + 'g, Error> {
         let node_idxs: Vec<_> = self.node_idxs(package_ids)?;
-        Ok(
-            self.transitive_dep_links_impl(
-                node_idxs,
-                &self.dep_graph,
-                DependencyDirection::Forward,
-            ),
-        )
+        Ok(self.transitive_dep_links_impl(node_idxs, &self.dep_graph))
     }
 
     /// Returns all transitive reverse dependency links for the given package IDs.
@@ -414,21 +419,19 @@ impl PackageGraph {
         package_ids: impl IntoIterator<Item = &'a PackageId>,
     ) -> Result<impl Iterator<Item = DependencyLink<'g>> + 'g, Error> {
         let node_idxs: Vec<_> = self.node_idxs(package_ids)?;
-        Ok(self.transitive_dep_links_impl(
-            node_idxs,
-            ReversedDirected::new(&self.dep_graph),
-            DependencyDirection::Reverse,
-        ))
+        Ok(self.transitive_dep_links_impl(node_idxs, ReversedDirected::new(&self.dep_graph)))
     }
 
     fn transitive_dep_links_impl<'g, G>(
         &'g self,
         node_idxs: Vec<NodeIndex<u32>>,
         graph: G,
-        direction: DependencyDirection,
     ) -> impl Iterator<Item = DependencyLink<'g>> + 'g
     where
-        G: 'g + Visitable + IntoEdges<NodeId = NodeIndex<u32>, EdgeId = EdgeIndex<u32>>,
+        G: 'g
+            + Visitable
+            + IntoEdges<NodeId = NodeIndex<u32>, EdgeId = EdgeIndex<u32>>
+            + ReverseFlip<NodeId = NodeIndex<u32>>,
         G::Map: VisitMap<NodeIndex<u32>>,
     {
         let edge_dfs = EdgeDfs::new(graph, node_idxs);
@@ -440,11 +443,7 @@ impl PackageGraph {
                 // and 'to' are always right way up. Note that this doesn't have to be done for
                 // deps_impl because we don't reverse the actual graph, just use incoming edges
                 // there.
-                // XXX having G and direction be separate but linked is unfortunate.
-                let (source_idx, target_idx) = match direction {
-                    DependencyDirection::Forward => (source_idx, target_idx),
-                    DependencyDirection::Reverse => (target_idx, source_idx),
-                };
+                let (source_idx, target_idx) = graph.reverse_flip(source_idx, target_idx);
                 self.edge_to_link(source_idx, target_idx, &self.dep_graph[edge_idx])
             })
     }
@@ -504,7 +503,7 @@ impl PackageGraph {
     ///
     /// If you are only interested in package IDs, `topo_ids` is more efficient.
     pub fn all_links<'g>(&'g self) -> impl Iterator<Item = DependencyLink<'g>> + 'g {
-        self.all_links_impl(&self.dep_graph, DependencyDirection::Forward)
+        self.all_links_impl(&self.dep_graph)
     }
 
     /// Returns all dependency links in this graph in reverse order.
@@ -514,30 +513,21 @@ impl PackageGraph {
     ///
     /// If you are only interested in package IDs, `reverse_topo_ids` is more efficient.
     pub fn all_reverse_links<'g>(&'g self) -> impl Iterator<Item = DependencyLink<'g>> + 'g {
-        self.all_links_impl(
-            ReversedDirected::new(&self.dep_graph),
-            DependencyDirection::Reverse,
-        )
+        self.all_links_impl(ReversedDirected::new(&self.dep_graph))
     }
 
-    fn all_links_impl<'g, G>(
-        &'g self,
-        graph: G,
-        direction: DependencyDirection,
-    ) -> impl Iterator<Item = DependencyLink<'g>> + 'g
+    fn all_links_impl<'g, G>(&'g self, graph: G) -> impl Iterator<Item = DependencyLink<'g>> + 'g
     where
         G: 'g
             + Visitable
             + IntoNodeIdentifiers
             + IntoNeighborsDirected
-            + IntoEdges<NodeId = NodeIndex<u32>, EdgeId = EdgeIndex<u32>>,
+            + IntoEdges<NodeId = NodeIndex<u32>, EdgeId = EdgeIndex<u32>>
+            + ReverseFlip<NodeId = NodeIndex<u32>>,
         G::Map: VisitMap<NodeIndex<u32>>,
     {
-        // XXX requiring both the graph and the direction to be passed in is supremely ugly.
-        // Should be fixable with a custom trait.
-
         // Perform a transitive dep traversal from the roots in the graph.
-        self.transitive_dep_links_impl(Self::roots(graph), graph, direction)
+        self.transitive_dep_links_impl(Self::roots(graph), graph)
     }
 
     // ---

--- a/cargo-guppy-lib/src/graph/visit/reversed.rs
+++ b/cargo-guppy-lib/src/graph/visit/reversed.rs
@@ -37,7 +37,60 @@ where
 }
 
 // ---
-// New trait impls
+// New traits
+// ---
+
+/// Provides a way to flip source and target indexes for reversed graphs.
+///
+/// Some operations that are generic over forward and reverse graphs may want the original
+/// direction. This trait provides that.
+pub trait ReverseFlip {
+    /// Node index type.
+    type NodeId;
+
+    /// Flip the source and target indexes if this is a reversed graph. Leave them the same if it
+    /// isn't.
+    fn reverse_flip(
+        self,
+        source: Self::NodeId,
+        target: Self::NodeId,
+    ) -> (Self::NodeId, Self::NodeId);
+}
+
+impl<'a, NW, EW, Ty, Ix> ReverseFlip for &'a Graph<NW, EW, Ty, Ix> {
+    type NodeId = NodeIndex<Ix>;
+
+    fn reverse_flip(
+        self,
+        source: Self::NodeId,
+        target: Self::NodeId,
+    ) -> (Self::NodeId, Self::NodeId) {
+        // A graph itself is in the forward direction.
+        (source, target)
+    }
+}
+
+impl<'a, G, N> ReverseFlip for ReversedDirected<&'a G>
+where
+    N: Copy + PartialEq,
+    G: GraphBase<NodeId = N>,
+    &'a G: ReverseFlip<NodeId = N>,
+{
+    type NodeId = N;
+
+    fn reverse_flip(
+        self,
+        source: Self::NodeId,
+        target: Self::NodeId,
+    ) -> (Self::NodeId, Self::NodeId) {
+        // This allows nested reversed graphs to do the right thing.
+        let (target, source) = self.0.reverse_flip(source, target);
+        (source, target)
+    }
+}
+
+// ---
+// New impls for existing traits
 // ---
 
 impl<G> IntoEdges for ReversedDirected<G>


### PR DESCRIPTION
Using both a type and a value to represent a reversed graph was proving to be really annoying, and was impeding the dot printer. Clean it up.