### PR TITLE
[dot] include roots in reachability queries

### DIFF
--- a/cargo-guppy-lib/src/graph/print.rs
+++ b/cargo-guppy-lib/src/graph/print.rs
@@ -4,7 +4,7 @@ use crate::graph::visit::reversed::{ReverseFlip, ReversedDirected};
 use crate::graph::{DependencyEdge, DependencyLink, PackageGraph, PackageMetadata};
 use cargo_metadata::PackageId;
 use petgraph::prelude::*;
-use petgraph::visit::{IntoNeighbors, NodeFiltered, NodeRef, Visitable};
+use petgraph::visit::{IntoNeighbors, NodeFiltered, NodeRef, VisitMap, Visitable};
 use std::fmt;
 
 /// A visitor used for formatting `dot` graphs.
@@ -103,9 +103,13 @@ where
     G: Visitable + IntoNeighbors,
 {
     // To figure out what nodes are reachable, run a DFS starting from the roots.
-    let mut dfs = Dfs::from_parts(roots, graph.visit_map());
+    let mut visit_map = graph.visit_map();
+    roots.iter().for_each(|node_idx| {
+        visit_map.visit(*node_idx);
+    });
+    let mut dfs = Dfs::from_parts(roots, visit_map);
     while let Some(_) = dfs.next(graph) {}
 
-    // Once the DFS is done, the discovered map is what's allowed.
+    // Once the DFS is done, the discovered map is what's reachable.
     dfs.discovered
 }

--- a/cargo-guppy-lib/src/unit_tests/graph_tests.rs
+++ b/cargo-guppy-lib/src/unit_tests/graph_tests.rs
@@ -32,10 +32,15 @@ fn metadata1() {
     13 [label="winapi"]
     14 [label="libc"]
     20 [label="winapi-i686-pc-windows-gnu"]
+    26 [label="region"]
     31 [label="bitflags"]
     11 -> 14 [label="libc"]
     13 -> 20 [label="winapi-i686-pc-windows-gnu"]
     13 -> 0 [label="winapi-x86_64-pc-windows-gnu"]
+    26 -> 31 [label="bitflags"]
+    26 -> 14 [label="libc"]
+    26 -> 11 [label="mach"]
+    26 -> 13 [label="winapi"]
 }
 "#;
     assert_eq!(
@@ -56,8 +61,10 @@ fn metadata1() {
     static EXPECTED_DOT_REVERSED: &str = r#"digraph {
     1 [label="datatest"]
     9 [label="serde_yaml"]
+    15 [label="dtoa"]
     18 [label="testcrate"]
     1 -> 9 [label="serde_yaml"]
+    9 -> 15 [label="dtoa"]
     18 -> 1 [label="datatest"]
 }
 "#;


### PR DESCRIPTION
Whoops, we forgot to include the roots. Updated tests as well.