### PR TITLE
Exposes targets from PackageMetadata

### DIFF
--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -210,6 +210,7 @@ impl<'a> GraphBuildState<'a> {
                 license: package.license.map(|s| s.into()),
                 license_file: package.license_file.map(|s| s.into()),
                 manifest_path: package.manifest_path.into(),
+                targets: package.targets,
                 categories: package.categories,
                 keywords: package.keywords,
                 readme: package.readme.map(|s| s.into()),

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -171,7 +171,8 @@ impl<'a> GraphBuildState<'a> {
             self.dep_graph.update_edge(node_idx, dep_idx, edge);
         }
 
-        let has_default_feature = package.features.contains_key("default");
+        let default_features = package.features.get("default").map(|s| s.clone());
+
 
         // Optional dependencies could in principle be computed by looking at the edges out of this
         // package, but unresolved dependencies aren't part of the graph so we're going to miss them
@@ -224,7 +225,7 @@ impl<'a> GraphBuildState<'a> {
                 node_idx,
                 workspace_path,
                 optional_deps,
-                has_default_feature,
+                default_features,
                 resolved_deps,
                 resolved_features,
             },

--- a/guppy/src/graph/feature.rs
+++ b/guppy/src/graph/feature.rs
@@ -359,7 +359,7 @@ impl<'g> FeatureGraphBuildState<'g> {
         let unified_features: HashSet<&str> = unified_metadata
             .flat_map(|metadata| {
                 // Packages without an explicit feature named "default" get pointed to the base.
-                let default = if metadata.uses_default_features() && to.has_default_feature() {
+                let default = if metadata.uses_default_features() && to.default_features().is_some() {
                     Some("default")
                 } else {
                     None

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -3,7 +3,7 @@
 
 use crate::graph::{kind_str, DependencyDirection, FeatureGraphImpl, PackageIx};
 use crate::{Error, JsonValue, Metadata, MetadataCommand, PackageId};
-use cargo_metadata::{DependencyKind, NodeDep};
+use cargo_metadata::{DependencyKind, NodeDep, Target};
 use fixedbitset::FixedBitSet;
 use lazy_static::lazy_static;
 use once_cell::sync::OnceCell;
@@ -496,6 +496,7 @@ pub struct PackageMetadata {
     pub(super) license: Option<Box<str>>,
     pub(super) license_file: Option<Box<Path>>,
     pub(super) manifest_path: Box<Path>,
+    pub(super) targets: Vec<Target>,
     pub(super) categories: Vec<String>,
     pub(super) keywords: Vec<String>,
     pub(super) readme: Option<Box<Path>>,
@@ -639,6 +640,11 @@ impl PackageMetadata {
     /// Returns true if this package is in the workspace.
     pub fn in_workspace(&self) -> bool {
         self.workspace_path.is_some()
+    }
+
+    /// Returns the build targets for the package
+    pub fn targets(&self) -> impl Iterator<Item = &Target> + ExactSizeIterator {
+        self.targets.iter()
     }
 
     /// Returns the relative path to this package in the workspace, or `None` if this package is

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -642,7 +642,7 @@ impl PackageMetadata {
         self.workspace_path.is_some()
     }
 
-    /// Returns the build targets for the package
+    /// Returns the build targets for the package.
     pub fn targets(&self) -> impl Iterator<Item = &Target> + ExactSizeIterator {
         self.targets.iter()
     }

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -510,7 +510,7 @@ pub struct PackageMetadata {
     // Other information.
     pub(super) node_idx: NodeIndex<PackageIx>,
     pub(super) workspace_path: Option<Box<Path>>,
-    pub(super) has_default_feature: bool,
+    pub(super) default_features: Option<Vec<String>>,
     pub(super) optional_deps: HashSet<Box<str>>,
     pub(super) resolved_deps: Vec<NodeDep>,
     pub(super) resolved_features: Vec<String>,
@@ -653,13 +653,13 @@ impl PackageMetadata {
         self.workspace_path.as_ref().map(|path| path.as_ref())
     }
 
-    /// Returns true if this package has a named feature named `default`.
+    /// Returns the `default` features if present in the package.
     ///
     /// For more about default features, see [The `[features]`
     /// section](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section) in
     /// the Cargo reference.
-    pub fn has_default_feature(&self) -> bool {
-        self.has_default_feature
+    pub fn default_features(&self) -> Option<&[String]>{
+        self.default_features.as_ref().map(|features| features.as_slice())
     }
 
     /// Returns the list of named features available for this package. This will include the default


### PR DESCRIPTION
I have some concerns about this approach as it exposes underlying cargo_metadata types to the api surface. I'm not sure what sort of versioning contract you want to keep between the two crates.