### PR TITLE
[admin] update repository links to point to the new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cargo-guppy: track and query dependency graphs
 
-[![Build Status](https://circleci.com/gh/calibra/cargo-guppy/tree/master.svg?style=shield)](https://circleci.com/gh/calibra/cargo-guppy/tree/master) [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE-APACHE) [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE-MIT)
+[![Build Status](https://circleci.com/gh/facebookincubator/cargo-guppy/tree/master.svg?style=shield)](https://circleci.com/gh/facebookincubator/cargo-guppy/tree/master) [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE-APACHE) [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE-MIT)
 
 This repository contains the source code for:
 * [`guppy`](guppy): a library for performing queries on Cargo dependency graphs [![guppy on crates.io](https://img.shields.io/crates/v/guppy)](https://crates.io/crates/guppy) [![Documentation (latest release)](https://docs.rs/guppy/badge.svg)](https://docs.rs/guppy/) [![Documentation (master)](https://img.shields.io/badge/docs-master-59f)](https://calibra.github.io/cargo-guppy/guppy/)

--- a/guppy/CHANGELOG.md
+++ b/guppy/CHANGELOG.md
@@ -73,13 +73,13 @@ lazy_static = "0.2"
 ### Added
 - Initial release.
 
-[0.1.7]: https://github.com/calibra/cargo-guppy/releases/tag/guppy-0.1.7
+[0.1.7]: https://github.com/facebookincubator/cargo-guppy/releases/tag/guppy-0.1.7
 
 <!-- Previous releases were simply tagged "$VERSION", not "guppy-$VERSION". -->
-[0.1.6]: https://github.com/calibra/cargo-guppy/releases/tag/0.1.6
-[0.1.5]: https://github.com/calibra/cargo-guppy/releases/tag/0.1.5
-[0.1.4]: https://github.com/calibra/cargo-guppy/releases/tag/0.1.4
-[0.1.3]: https://github.com/calibra/cargo-guppy/releases/tag/0.1.3
-[0.1.2]: https://github.com/calibra/cargo-guppy/releases/tag/0.1.2
-[0.1.1]: https://github.com/calibra/cargo-guppy/releases/tag/0.1.1
-[0.1.0]: https://github.com/calibra/cargo-guppy/releases/tag/0.1.0
+[0.1.6]: https://github.com/facebookincubator/cargo-guppy/releases/tag/0.1.6
+[0.1.5]: https://github.com/facebookincubator/cargo-guppy/releases/tag/0.1.5
+[0.1.4]: https://github.com/facebookincubator/cargo-guppy/releases/tag/0.1.4
+[0.1.3]: https://github.com/facebookincubator/cargo-guppy/releases/tag/0.1.3
+[0.1.2]: https://github.com/facebookincubator/cargo-guppy/releases/tag/0.1.2
+[0.1.1]: https://github.com/facebookincubator/cargo-guppy/releases/tag/0.1.1
+[0.1.0]: https://github.com/facebookincubator/cargo-guppy/releases/tag/0.1.0

--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -3,7 +3,7 @@ name = "guppy"
 version = "0.1.7"
 description = "Track and query Cargo dependency graphs."
 documentation = "https://docs.rs/guppy"
-repository = "https://github.com/calibra/cargo-guppy"
+repository = "https://github.com/facebookincubator/cargo-guppy"
 authors = ["Rain <rain1@calibra.com>", "Brandon Williams <bmwill@calibra.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -23,7 +23,7 @@ exclude = [
 all-features = true
 
 [badges]
-circle-ci = { repository = "calibra/cargo-guppy", branch = "master"}
+circle-ci = { repository = "facebookincubator/cargo-guppy", branch = "master"}
 maintenance = { status = "actively-developed" }
 
 [dependencies]

--- a/guppy/README.md
+++ b/guppy/README.md
@@ -42,7 +42,7 @@ for link in package_graph.dep_links(&package_id).unwrap() {
 ```
 
 For more examples, see
-[the `examples` directory](https://github.com/calibra/cargo-guppy/tree/master/guppy/examples).
+[the `examples` directory](https://github.com/facebookincubator/cargo-guppy/tree/master/guppy/examples).
 
 ## Contributing
 

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -22,7 +22,7 @@ use target_spec::TargetSpec;
 /// metadata`.
 ///
 /// For examples on how to use `PackageGraph`, see
-/// [the `examples` directory](https://github.com/calibra/cargo-guppy/tree/master/guppy/examples)
+/// [the `examples` directory](https://github.com/facebookincubator/cargo-guppy/tree/master/guppy/examples)
 /// in this crate.
 #[derive(Clone, Debug)]
 pub struct PackageGraph {

--- a/guppy/src/lib.rs
+++ b/guppy/src/lib.rs
@@ -41,7 +41,7 @@
 //! ```
 //!
 //! For more examples, see
-//! [the `examples` directory](https://github.com/calibra/cargo-guppy/tree/master/guppy/examples).
+//! [the `examples` directory](https://github.com/facebookincubator/cargo-guppy/tree/master/guppy/examples).
 
 #![warn(missing_docs)]
 

--- a/target-spec/CHANGELOG.md
+++ b/target-spec/CHANGELOG.md
@@ -11,5 +11,5 @@
 ## [0.1.0] - 2020-03-20
 - Initial release.
 
-[0.2.0]: https://github.com/calibra/cargo-guppy/releases/tag/target-spec-0.2.0
-[0.1.0]: https://github.com/calibra/cargo-guppy/releases/tag/target-spec-0.1.0
+[0.2.0]: https://github.com/facebookincubator/cargo-guppy/releases/tag/target-spec-0.2.0
+[0.1.0]: https://github.com/facebookincubator/cargo-guppy/releases/tag/target-spec-0.1.0

--- a/target-spec/Cargo.toml
+++ b/target-spec/Cargo.toml
@@ -3,7 +3,7 @@ name = "target-spec"
 version = "0.2.0"
 description = "Evaluate Cargo.toml target specifications"
 documentation = "https://docs.rs/target-spec"
-repository = "https://github.com/calibra/cargo-guppy"
+repository = "https://github.com/facebookincubator/cargo-guppy"
 authors = ["Jack Moffitt <metajack@fb.com>", "Rain <rain1@calibra.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -12,7 +12,7 @@ categories = ["development-tools", "parser-implementations"]
 edition = "2018"
 
 [badges]
-circle-ci = { repository = "calibra/cargo-guppy", branch = "master" }
+circle-ci = { repository = "facebookincubator/cargo-guppy", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]


### PR DESCRIPTION
The repo has moved to the facebookincubator org.