### PR TITLE
[cargo-guppy] cleanup + implement --select-reverse and --output-reverse

### DIFF
--- a/cargo-guppy/src/core.rs
+++ b/cargo-guppy/src/core.rs
@@ -1,0 +1,107 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Implementations for options shared by commands.
+
+use clap::arg_enum;
+use guppy::graph::{DependencyLink, EnabledStatus, PackageGraph};
+use guppy::{Platform, TargetFeatures};
+use std::collections::HashSet;
+use structopt::StructOpt;
+
+arg_enum! {
+    #[derive(Debug)]
+    pub enum Kind {
+        All,
+        Workspace,
+        DirectThirdParty,
+        ThirdParty,
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct FilterOptions {
+    #[structopt(long, short, possible_values = &Kind::variants(), case_insensitive = true, default_value = "all")]
+    /// Kind of crates to select
+    pub kind: Kind,
+
+    #[structopt(long, rename_all = "kebab-case")]
+    /// Include dev dependencies
+    pub include_dev: bool,
+
+    #[structopt(long, rename_all = "kebab-case")]
+    /// Include build dependencies
+    pub include_build: bool,
+
+    #[structopt(long)]
+    /// Target to select for, default is to match all targets
+    pub target: Option<String>,
+
+    #[structopt(
+        long,
+        rename_all = "kebab-case",
+        name = "package",
+        number_of_values = 1
+    )]
+    /// Omit edges that point into a given package; useful for seeing how
+    /// removing a dependency affects the graph
+    pub omit_edges_into: Vec<String>,
+}
+
+impl FilterOptions {
+    /// Construct a package resolver based on the filter options.
+    pub fn make_resolver<'g>(
+        &'g self,
+        pkg_graph: &'g PackageGraph,
+    ) -> impl Fn(DependencyLink<'g>) -> bool + 'g {
+        let omitted_set: HashSet<&str> = self.omit_edges_into.iter().map(|s| s.as_str()).collect();
+
+        let mut omitted_package_ids = HashSet::new();
+        for metadata in pkg_graph.packages() {
+            if omitted_set.contains(metadata.name()) {
+                omitted_package_ids.insert(metadata.id().clone());
+            }
+        }
+
+        let platform = if let Some(ref target) = self.target {
+            // The features are unknown.
+            Some(Platform::new(target, TargetFeatures::Unknown).unwrap())
+        } else {
+            None
+        };
+
+        move |DependencyLink { from, to, edge }| {
+            // filter by the kind of dependency (--kind)
+            // NOTE: We always retain all workspace deps in the graph, otherwise
+            // we'll get a disconnected graph.
+            let include_kind = match self.kind {
+                Kind::All | Kind::ThirdParty => true,
+                Kind::DirectThirdParty => from.in_workspace(),
+                Kind::Workspace => from.in_workspace() && to.in_workspace(),
+            };
+
+            // filter out irrelevant dependencies for a specific target (--target)
+            let include_target = if let Some(platform) = &platform {
+                edge.normal()
+                    .map(|meta| {
+                        // Include this dependency if it's optional or mandatory or if the status is
+                        // unknown.
+                        meta.enabled_on(platform) != EnabledStatus::Never
+                    })
+                    .unwrap_or(true)
+            } else {
+                true
+            };
+
+            // filter normal, dev, and build dependencies (--include-build, --include-dev)
+            let include_type = edge.normal().is_some()
+                || self.include_dev && edge.dev().is_some()
+                || self.include_build && edge.build().is_some();
+
+            // filter out provided edge targets (--omit-edges-into)
+            let include_edge = !omitted_package_ids.contains(to.id());
+
+            include_kind && include_target && include_type && include_edge
+        }
+    }
+}

--- a/cargo-guppy/src/lib.rs
+++ b/cargo-guppy/src/lib.rs
@@ -83,7 +83,7 @@ impl PackageDotVisitor for NameVisitor {
 }
 
 #[derive(Debug, StructOpt)]
-pub struct SelectOptions {
+pub struct CmdSelectOptions {
     #[structopt(flatten)]
     filter_opts: FilterOptions,
 
@@ -96,7 +96,7 @@ pub struct SelectOptions {
     roots: Vec<String>,
 }
 
-pub fn cmd_select(options: &SelectOptions) -> Result<(), anyhow::Error> {
+pub fn cmd_select(options: &CmdSelectOptions) -> Result<(), anyhow::Error> {
     let mut command = MetadataCommand::new();
     let pkg_graph = PackageGraph::from_command(&mut command)?;
     let mut package_ids = HashSet::new();

--- a/cargo-guppy/src/lib.rs
+++ b/cargo-guppy/src/lib.rs
@@ -87,6 +87,10 @@ pub struct CmdSelectOptions {
     #[structopt(flatten)]
     filter_opts: FilterOptions,
 
+    #[structopt(long = "output-reverse", parse(from_flag = parse_direction))]
+    /// Output results in reverse topological order (default: forward)
+    output_direction: DependencyDirection,
+
     #[structopt(long, rename_all = "kebab-case")]
     /// Save selection graph in .dot format
     output_dot: Option<String>,
@@ -103,7 +107,7 @@ pub fn cmd_select(options: &CmdSelectOptions) -> Result<(), anyhow::Error> {
     let resolver = options.filter_opts.make_resolver(&pkg_graph);
     let resolve = select.resolve_with_fn(resolver);
 
-    for package_id in resolve.clone().into_ids(DependencyDirection::Forward) {
+    for package_id in resolve.clone().into_ids(options.output_direction) {
         let package = pkg_graph.metadata(package_id).unwrap();
         let in_workspace = package.in_workspace();
         let direct_dep = pkg_graph

--- a/cargo-guppy/src/lib.rs
+++ b/cargo-guppy/src/lib.rs
@@ -100,7 +100,6 @@ pub fn cmd_select(options: &CmdSelectOptions) -> Result<(), anyhow::Error> {
     let mut command = MetadataCommand::new();
     let pkg_graph = PackageGraph::from_command(&mut command)?;
     let mut package_ids = HashSet::new();
-    let mut omitted_package_ids = HashSet::new();
 
     // NOTE: The root set packages are specified by name. The tool currently
     // does not handle multiple version of the same package as the current use
@@ -116,19 +115,9 @@ pub fn cmd_select(options: &CmdSelectOptions) -> Result<(), anyhow::Error> {
             .collect()
     };
 
-    let omitted_set: HashSet<String> = options
-        .filter_opts
-        .omit_edges_into
-        .iter()
-        .cloned()
-        .collect();
-
     for metadata in pkg_graph.packages() {
         if root_set.contains(metadata.name()) {
             package_ids.insert(metadata.id().clone());
-        }
-        if omitted_set.contains(metadata.name()) {
-            omitted_package_ids.insert(metadata.id().clone());
         }
     }
 

--- a/cargo-guppy/src/main.rs
+++ b/cargo-guppy/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use cargo_guppy::{FilterOptions, SelectOptions, SubtreeSizeOptions};
+use cargo_guppy::{CmdSelectOptions, FilterOptions, SubtreeSizeOptions};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -26,7 +26,7 @@ enum Command {
     Duplicates(FilterOptions),
     #[structopt(name = "select")]
     /// Select packages and their transitive dependencies
-    Select(SelectOptions),
+    Select(CmdSelectOptions),
     #[structopt(name = "subtree-size")]
     /// Print a list of dependencies along with their unique subtree size
     SubtreeSize(SubtreeSizeOptions),


### PR DESCRIPTION
Implement a couple of flags that I found useful while trying to figure out why a package was included in the build.