### PR TITLE
re-do platform-specific statuses 

### DIFF
--- a/cargo-guppy/src/core.rs
+++ b/cargo-guppy/src/core.rs
@@ -113,7 +113,7 @@ impl FilterOptions {
             let include_target = if let Some(platform) = &platform {
                 edge.normal()
                     .map(|meta| {
-                        // Include this dependency if it's optional or mandatory or if the status is
+                        // Include this dependency if it's optional or required or if the status is
                         // unknown.
                         meta.enabled_on(platform) != EnabledStatus::Never
                     })

--- a/guppy/CHANGELOG.md
+++ b/guppy/CHANGELOG.md
@@ -66,7 +66,7 @@ This is a breaking release. There are no new or removed features, but many exist
 ## [0.1.7] - 2020-04-05
 ### Added
 - Support for [platform-specific dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies), including:
-   - Querying whether a dependency is mandatory or optional on the current platform, or on any other platform.
+   - Querying whether a dependency is required or optional on the current platform, or on any other platform.
    - Evaluating which features are enabled on a platform.
    - Handling situations where the set of [target features](https://github.com/rust-lang/rfcs/blob/master/text/2045-target-feature.md) isn't known.
 

--- a/guppy/src/errors.rs
+++ b/guppy/src/errors.rs
@@ -25,8 +25,6 @@ pub enum Error {
     UnknownPackageId(PackageId),
     /// A feature ID was unknown to this `FeatureGraph`.
     UnknownFeatureId(PackageId, Option<String>),
-    /// The platform `guppy` is running on is unknown.
-    UnknownCurrentPlatform,
     /// An internal error occurred within this `PackageGraph`.
     PackageGraphInternalError(String),
 }
@@ -48,7 +46,6 @@ impl fmt::Display for Error {
                 Some(feature) => write!(f, "Unknown feature ID: '{}' '{}'", package_id, feature),
                 None => write!(f, "Unknown feature ID: '{}' (base)", package_id),
             },
-            UnknownCurrentPlatform => write!(f, "Unknown current platform"),
             PackageGraphInternalError(msg) => write!(f, "Internal error in package graph: {}", msg),
         }
     }
@@ -62,7 +59,6 @@ impl error::Error for Error {
             PackageGraphConstructError(_) => None,
             UnknownPackageId(_) => None,
             UnknownFeatureId(_, _) => None,
-            UnknownCurrentPlatform => None,
             PackageGraphInternalError(_) => None,
         }
     }

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -625,7 +625,7 @@ impl PackageEdgeImpl {
 /// 1. Whether the dependency is included at all. This is a union of all instances, conditional on
 ///    the specifics of the `[target]` lines.
 /// 2. What features are enabled. As of cargo 1.42, this is unified across all instances but
-///    separately for mandatory/optional instances.
+///    separately for required/optional instances.
 ///
 /// Note that the new feature resolver
 /// (https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#features)'s `itarget` setting
@@ -663,7 +663,7 @@ impl DependencyBuildState {
         let current_enabled = dependency_req.enabled_on(&current_platform);
         let current_default_features = dependency_req.default_features_on(&current_platform);
 
-        // Collect all features from both the optional and mandatory instances.
+        // Collect all features from both the optional and required instances.
         let all_features: HashSet<_> = dependency_req.all_features().collect();
         let all_features: Vec<_> = all_features
             .into_iter()
@@ -696,12 +696,12 @@ impl DependencyReq {
         if dep.optional {
             self.optional.add_instance(from_id, dep)
         } else {
-            self.mandatory.add_instance(from_id, dep)
+            self.required.add_instance(from_id, dep)
         }
     }
 
     fn all_features(&self) -> impl Iterator<Item = &str> {
-        self.mandatory
+        self.required
             .all_features()
             .chain(self.optional.all_features())
     }

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -4,7 +4,7 @@
 use crate::graph::{
     cargo_version_matches, BuildTargetImpl, BuildTargetKind, DepRequiredOrOptional,
     DependencyMetadata, DependencyReq, OwnedBuildTargetId, PackageEdgeImpl, PackageGraph,
-    PackageGraphData, PackageIx, PackageMetadata, TargetPredicate, WorkspaceImpl,
+    PackageGraphData, PackageIx, PackageMetadata, PlatformStatusImpl, WorkspaceImpl,
 };
 use crate::{Error, Metadata, PackageId, Platform};
 use cargo_metadata::{Dependency, DependencyKind, NodeDep, Package, Resolve, Target};
@@ -735,18 +735,18 @@ impl DepRequiredOrOptional {
     }
 }
 
-impl TargetPredicate {
-    pub(super) fn extend(&mut self, other: &TargetPredicate) {
+impl PlatformStatusImpl {
+    pub(super) fn extend(&mut self, other: &PlatformStatusImpl) {
         // &mut *self is a reborrow to allow mem::replace to work below.
         match (&mut *self, other) {
-            (TargetPredicate::Always, _) => {
+            (PlatformStatusImpl::Always, _) => {
                 // Always stays the same since it means all specs are included.
             }
-            (TargetPredicate::Specs(_), TargetPredicate::Always) => {
+            (PlatformStatusImpl::Specs(_), PlatformStatusImpl::Always) => {
                 // Mark self as Always.
-                mem::replace(self, TargetPredicate::Always);
+                mem::replace(self, PlatformStatusImpl::Always);
             }
-            (TargetPredicate::Specs(specs), TargetPredicate::Specs(other)) => {
+            (PlatformStatusImpl::Specs(specs), PlatformStatusImpl::Specs(other)) => {
                 specs.extend_from_slice(other.as_slice());
             }
         }
@@ -755,23 +755,23 @@ impl TargetPredicate {
     pub(super) fn add_spec(&mut self, spec: Option<&TargetSpec>) {
         // &mut *self is a reborrow to allow mem::replace to work below.
         match (&mut *self, spec) {
-            (TargetPredicate::Always, _) => {
+            (PlatformStatusImpl::Always, _) => {
                 // Always stays the same since it means all specs are included.
             }
-            (TargetPredicate::Specs(_), None) => {
+            (PlatformStatusImpl::Specs(_), None) => {
                 // Mark self as Always.
-                mem::replace(self, TargetPredicate::Always);
+                mem::replace(self, PlatformStatusImpl::Always);
             }
-            (TargetPredicate::Specs(specs), Some(spec)) => {
+            (PlatformStatusImpl::Specs(specs), Some(spec)) => {
                 specs.push(spec.clone());
             }
         }
     }
 }
 
-impl Default for TargetPredicate {
+impl Default for PlatformStatusImpl {
     fn default() -> Self {
         // Empty vector means never.
-        TargetPredicate::Specs(vec![])
+        PlatformStatusImpl::Specs(vec![])
     }
 }

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::graph::{
-    cargo_version_matches, BuildTargetImpl, BuildTargetKind, DependencyMetadata, DependencyReq,
-    DependencyReqImpl, OwnedBuildTargetId, PackageEdgeImpl, PackageGraph, PackageGraphData,
-    PackageIx, PackageMetadata, TargetPredicate, WorkspaceImpl,
+    cargo_version_matches, BuildTargetImpl, BuildTargetKind, DepRequiredOrOptional,
+    DependencyMetadata, DependencyReq, OwnedBuildTargetId, PackageEdgeImpl, PackageGraph,
+    PackageGraphData, PackageIx, PackageMetadata, TargetPredicate, WorkspaceImpl,
 };
 use crate::{Error, Metadata, PackageId, Platform};
 use cargo_metadata::{Dependency, DependencyKind, NodeDep, Package, Resolve, Target};
@@ -707,7 +707,7 @@ impl DependencyReq {
     }
 }
 
-impl DependencyReqImpl {
+impl DepRequiredOrOptional {
     fn add_instance(&mut self, from_id: &PackageId, dep: &Dependency) -> Result<(), Error> {
         // target_spec is None if this is not a platform-specific dependency.
         let target_spec = match dep.target.as_ref() {

--- a/guppy/src/graph/feature/build.rs
+++ b/guppy/src/graph/feature/build.rs
@@ -225,8 +225,8 @@ impl<'g> FeatureGraphBuildState<'g> {
         //   features "a" and "b" in both instances.
         //
         // This means that up to two separate edges have to be represented:
-        // * a 'mandatory edge', which will be from the base node for 'from' to the feature nodes
-        //   for each mandatory feature in 'to'.
+        // * a 'required edge', which will be from the base node for 'from' to the feature nodes
+        //   for each required feature in 'to'.
         // * an 'optional edge', which will be from the feature node (from, dep_name) to the
         //   feature nodes for each optional feature in 'to'. This edge is only added if at least
         //   one line is optional.
@@ -246,12 +246,12 @@ impl<'g> FeatureGraphBuildState<'g> {
                 None
             });
 
-        let mut mandatory_req = FeatureReq::new(from, to, edge);
+        let mut required_req = FeatureReq::new(from, to, edge);
         let mut optional_req = FeatureReq::new(from, to, edge);
         for (dep_kind, metadata) in unified_metadata {
-            mandatory_req.add_features(
+            required_req.add_features(
                 dep_kind,
-                &metadata.dependency_req.mandatory,
+                &metadata.dependency_req.required,
                 &mut self.warnings,
             );
             optional_req.add_features(
@@ -261,8 +261,8 @@ impl<'g> FeatureGraphBuildState<'g> {
             );
         }
 
-        // Add the mandatory edges (base -> features).
-        self.add_edges(FeatureNode::base(from.package_ix), mandatory_req.finish());
+        // Add the required edges (base -> features).
+        self.add_edges(FeatureNode::base(from.package_ix), required_req.finish());
 
         if !optional_req.is_empty() {
             // This means that there is at least one instance of this dependency with optional =

--- a/guppy/src/graph/feature/build.rs
+++ b/guppy/src/graph/feature/build.rs
@@ -7,7 +7,7 @@ use crate::graph::feature::{
 };
 use crate::graph::{
     DepRequiredOrOptional, FeatureIx, PackageEdge, PackageGraph, PackageLink, PackageMetadata,
-    TargetPredicate,
+    PlatformStatusImpl,
 };
 use cargo_metadata::DependencyKind;
 use once_cell::sync::OnceCell;
@@ -425,13 +425,13 @@ impl<'g> FeatureReq<'g> {
 
 #[derive(Debug, Default)]
 struct DependencyBuildState {
-    normal: TargetPredicate,
-    build: TargetPredicate,
-    dev: TargetPredicate,
+    normal: PlatformStatusImpl,
+    build: PlatformStatusImpl,
+    dev: PlatformStatusImpl,
 }
 
 impl DependencyBuildState {
-    fn add_predicate(&mut self, dep_kind: DependencyKind, pred: &TargetPredicate) {
+    fn add_predicate(&mut self, dep_kind: DependencyKind, pred: &PlatformStatusImpl) {
         match dep_kind {
             DependencyKind::Normal => self.normal.extend(pred),
             DependencyKind::Build => self.build.extend(pred),

--- a/guppy/src/graph/feature/build.rs
+++ b/guppy/src/graph/feature/build.rs
@@ -6,7 +6,7 @@ use crate::graph::feature::{
     FeatureEdge, FeatureGraphImpl, FeatureMetadataImpl, FeatureNode, FeatureType,
 };
 use crate::graph::{
-    DependencyReqImpl, FeatureIx, PackageEdge, PackageGraph, PackageLink, PackageMetadata,
+    DepRequiredOrOptional, FeatureIx, PackageEdge, PackageGraph, PackageLink, PackageMetadata,
     TargetPredicate,
 };
 use cargo_metadata::DependencyKind;
@@ -362,7 +362,7 @@ impl<'g> FeatureReq<'g> {
     fn add_features(
         &mut self,
         dep_kind: DependencyKind,
-        req: &DependencyReqImpl,
+        req: &DepRequiredOrOptional,
         warnings: &mut Vec<FeatureGraphWarning>,
     ) {
         if let (Some(default_idx), false) =

--- a/guppy/src/graph/feature/graph_impl.rs
+++ b/guppy/src/graph/feature/graph_impl.rs
@@ -5,7 +5,7 @@ use crate::errors::FeatureGraphWarning;
 use crate::graph::feature::build::FeatureGraphBuildState;
 use crate::graph::feature::{Cycles, FeatureFilter};
 use crate::graph::{
-    DependencyDirection, FeatureIx, PackageGraph, PackageIx, PackageMetadata, TargetPredicate,
+    DependencyDirection, FeatureIx, PackageGraph, PackageIx, PackageMetadata, PlatformStatusImpl,
 };
 use crate::petgraph_support::scc::Sccs;
 use crate::{Error, PackageId};
@@ -510,9 +510,9 @@ pub(crate) enum FeatureEdge {
     /// foo = { version = "1", features = ["a", "b"] }
     /// ```
     Dependency {
-        normal: TargetPredicate,
-        build: TargetPredicate,
-        dev: TargetPredicate,
+        normal: PlatformStatusImpl,
+        build: PlatformStatusImpl,
+        dev: PlatformStatusImpl,
     },
     /// This edge is from a feature depending on other features:
     ///

--- a/guppy/src/graph/feature/graph_impl.rs
+++ b/guppy/src/graph/feature/graph_impl.rs
@@ -23,7 +23,7 @@ use std::iter::FromIterator;
 // optional dependencies.
 //
 // An optional dependency can be either normal or build -- not dev. Note that a dependency can be
-// marked optional in one section and mandatory in another. In this context, a dependency is a
+// marked optional in one section and required in another. In this context, a dependency is a
 // feature if it is marked as optional in any context.
 //
 // Features are *unified*. See the documentation in add_dependency_edges for more.

--- a/guppy/src/graph/feature/graph_impl.rs
+++ b/guppy/src/graph/feature/graph_impl.rs
@@ -500,7 +500,7 @@ impl FeatureNode {
 
 /// Information about why a feature depends on another feature.
 #[derive(Clone, Debug)]
-pub(in crate::graph) enum FeatureEdge {
+pub(crate) enum FeatureEdge {
     /// This edge is from a feature to its base package.
     FeatureToBase,
     /// This edge is present because a feature is enabled in a dependency, e.g. through:

--- a/guppy/src/graph/feature/resolve.rs
+++ b/guppy/src/graph/feature/resolve.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::debug_ignore::DebugIgnore;
-use crate::graph::feature::{FeatureFilter, FeatureGraph, FeatureId, FeatureMetadata};
+use crate::graph::feature::{FeatureEdge, FeatureFilter, FeatureGraph, FeatureId, FeatureMetadata};
 use crate::graph::query_core::QueryParams;
 use crate::graph::resolve_core::{ResolveCore, Topo};
 use crate::graph::{DependencyDirection, PackageMetadata, PackageSet};
@@ -341,6 +341,31 @@ impl<'g> FeatureSet<'g> {
                 } else {
                     None
                 }
+            })
+    }
+
+    // Currently a helper for debugging -- will be made public in the future.
+    #[allow(dead_code)]
+    pub(crate) fn into_links(
+        self,
+        direction: DependencyDirection,
+    ) -> impl Iterator<Item = (FeatureId<'g>, FeatureId<'g>, &'g FeatureEdge)> {
+        let feature_graph = self.feature_graph;
+
+        self.core
+            .links(feature_graph.dep_graph(), feature_graph.sccs(), direction)
+            .map(move |(source_ix, target_ix, edge_ix)| {
+                (
+                    FeatureId::from_node(
+                        feature_graph.package_graph(),
+                        &feature_graph.dep_graph()[source_ix],
+                    ),
+                    FeatureId::from_node(
+                        feature_graph.package_graph(),
+                        &feature_graph.dep_graph()[target_ix],
+                    ),
+                    &feature_graph.dep_graph()[edge_ix],
+                )
             })
     }
 }

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -1191,7 +1191,7 @@ impl DependencyReq {
 
     fn eval(
         &self,
-        pred_fn: impl Fn(&DepRequiredOrOptional) -> &TargetPredicate,
+        pred_fn: impl Fn(&DepRequiredOrOptional) -> &PlatformStatusImpl,
         platform: &Platform<'_>,
     ) -> EnabledStatus {
         let required_res = pred_fn(&self.required).eval(platform);
@@ -1230,8 +1230,8 @@ impl DependencyReq {
 /// optional.
 #[derive(Clone, Debug, Default)]
 pub(super) struct DepRequiredOrOptional {
-    pub(super) build_if: TargetPredicate,
-    pub(super) default_features_if: TargetPredicate,
+    pub(super) build_if: PlatformStatusImpl,
+    pub(super) default_features_if: PlatformStatusImpl,
     pub(super) target_features: Vec<(Option<TargetSpec>, Vec<String>)>,
 }
 
@@ -1245,26 +1245,26 @@ impl DepRequiredOrOptional {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum TargetPredicate {
+pub(crate) enum PlatformStatusImpl {
     Always,
     // Empty vector means never.
     Specs(Vec<TargetSpec>),
 }
 
-impl TargetPredicate {
+impl PlatformStatusImpl {
     /// Returns true if this is an empty predicate (i.e. will never match).
     pub(super) fn is_never(&self) -> bool {
         match self {
-            TargetPredicate::Always => false,
-            TargetPredicate::Specs(specs) => specs.is_empty(),
+            PlatformStatusImpl::Always => false,
+            PlatformStatusImpl::Specs(specs) => specs.is_empty(),
         }
     }
 
     /// Evaluates this target against the given platform triple.
     pub(super) fn eval(&self, platform: &Platform<'_>) -> Option<bool> {
         match self {
-            TargetPredicate::Always => Some(true),
-            TargetPredicate::Specs(specs) => {
+            PlatformStatusImpl::Always => Some(true),
+            PlatformStatusImpl::Specs(specs) => {
                 let mut res = Some(false);
                 for spec in specs.iter() {
                     let matches = spec.eval(platform);

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -1115,13 +1115,13 @@ pub enum EnabledStatus {
 }
 
 impl EnabledStatus {
-    /// Converts a mandatory evaluation result and a thunk returning the optional result into an
+    /// Converts a required evaluation result and a thunk returning the optional result into an
     /// `EnabledStatus`.
     pub(super) fn new(
-        mandatory_res: Option<bool>,
+        required_res: Option<bool>,
         optional_res_fn: impl FnOnce() -> Option<bool>,
     ) -> Self {
-        //    mandatory     optional     |      result
+        //    required     optional      |      result
         //                               |
         //        T            *         |      always
         //        U            T         |  optional present
@@ -1134,7 +1134,7 @@ impl EnabledStatus {
         // [1] note that both these cases are collapsed into "unknown" -- for either of these it's
         //     not known whether the dependency will be included at all.
 
-        match mandatory_res {
+        match required_res {
             Some(true) => EnabledStatus::Always,
             None => match optional_res_fn() {
                 Some(true) => EnabledStatus::Unknown(UnknownStatus::OptionalPresent),
@@ -1176,7 +1176,7 @@ pub enum UnknownStatus {
 /// Information about dependency requirements.
 #[derive(Clone, Debug, Default)]
 pub(super) struct DependencyReq {
-    pub(super) mandatory: DependencyReqImpl,
+    pub(super) required: DependencyReqImpl,
     pub(super) optional: DependencyReqImpl,
 }
 
@@ -1194,8 +1194,8 @@ impl DependencyReq {
         pred_fn: impl Fn(&DependencyReqImpl) -> &TargetPredicate,
         platform: &Platform<'_>,
     ) -> EnabledStatus {
-        let mandatory_res = pred_fn(&self.mandatory).eval(platform);
-        EnabledStatus::new(mandatory_res, || pred_fn(&self.optional).eval(platform))
+        let required_res = pred_fn(&self.required).eval(platform);
+        EnabledStatus::new(required_res, || pred_fn(&self.optional).eval(platform))
     }
 
     pub(super) fn feature_enabled_on(
@@ -1222,7 +1222,7 @@ impl DependencyReq {
             res
         };
 
-        EnabledStatus::new(matches(&self.mandatory), || matches(&self.optional))
+        EnabledStatus::new(matches(&self.required), || matches(&self.optional))
     }
 }
 

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -933,6 +933,7 @@ impl<'g> PackageEdge<'g> {
     // ---
 
     /// Returns the edge index.
+    #[allow(dead_code)]
     pub(super) fn edge_ix(&self) -> EdgeIndex<PackageIx> {
         self.edge_ix
     }

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -1243,7 +1243,7 @@ impl DependencyReqImpl {
 }
 
 #[derive(Clone, Debug)]
-pub(super) enum TargetPredicate {
+pub(crate) enum TargetPredicate {
     Always,
     // Empty vector means never.
     Specs(Vec<TargetSpec>),

--- a/guppy/src/graph/mod.rs
+++ b/guppy/src/graph/mod.rs
@@ -134,6 +134,7 @@ impl<'g> GraphSpec for feature::FeatureGraph<'g> {
     type Ix = FeatureIx;
 }
 
+#[allow(dead_code)]
 pub(crate) fn kind_str(kind: DependencyKind) -> &'static str {
     match kind {
         DependencyKind::Normal => "normal",

--- a/guppy/src/graph/resolve.rs
+++ b/guppy/src/graph/resolve.rs
@@ -376,7 +376,7 @@ impl<'g> Iterator for IntoLinks<'g> {
     type Item = PackageLink<'g>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (source_ix, target_ix, edge_ix) = self.inner.next_triple()?;
+        let (source_ix, target_ix, edge_ix) = self.inner.next()?;
         Some(self.graph.edge_to_link(source_ix, target_ix, edge_ix, None))
     }
 }

--- a/guppy/src/graph/resolve_core.rs
+++ b/guppy/src/graph/resolve_core.rs
@@ -256,11 +256,13 @@ impl<'g, G: GraphSpec> Links<'g, G> {
     pub(super) fn direction(&self) -> DependencyDirection {
         self.direction
     }
+}
 
+impl<'g, G: GraphSpec> Iterator for Links<'g, G> {
     #[allow(clippy::type_complexity)]
-    pub(super) fn next_triple(
-        &mut self,
-    ) -> Option<(NodeIndex<G::Ix>, NodeIndex<G::Ix>, EdgeIndex<G::Ix>)> {
+    type Item = (NodeIndex<G::Ix>, NodeIndex<G::Ix>, EdgeIndex<G::Ix>);
+
+    fn next(&mut self) -> Option<Self::Item> {
         match self.direction {
             DependencyDirection::Forward => {
                 // TODO: replace with &self.included once petgraph 0.5.1 is out.

--- a/guppy/src/unit_tests/fixtures.rs
+++ b/guppy/src/unit_tests/fixtures.rs
@@ -1051,7 +1051,7 @@ impl FixtureDetails {
 
         // testcrate -> dep-a.
         // As a normal dependency, this is optionally built by default, but on not-Windows or on x86
-        // it is mandatory.
+        // it is required.
         // As a dev dependency, it is present if sse2 or atomics are turned on.
         LinkDetails::new(
             package_id(METADATA_TARGETS1_TESTCRATE),

--- a/guppy/src/unit_tests/graph_tests.rs
+++ b/guppy/src/unit_tests/graph_tests.rs
@@ -186,6 +186,26 @@ mod small {
         let package_graph = metadata_targets1.graph();
         let package_set = package_graph.resolve_all();
         let feature_graph = metadata_targets1.graph().feature_graph();
+        assert_eq!(feature_graph.feature_count(), 31, "feature count");
+        for (source, target, edge) in feature_graph
+            .resolve_all()
+            .into_links(DependencyDirection::Forward)
+        {
+            let source_metadata = package_graph.metadata(source.package_id()).unwrap();
+            let target_metadata = package_graph.metadata(target.package_id()).unwrap();
+
+            println!(
+                "feature link: {}:{} {} -> {}:{} {} {:?}",
+                source_metadata.name(),
+                source_metadata.version(),
+                source.feature().unwrap_or("[base]"),
+                target_metadata.name(),
+                target_metadata.version(),
+                target.feature().unwrap_or("[base]"),
+                edge
+            );
+        }
+        assert_eq!(feature_graph.link_count(), 48, "feature link count");
 
         // Check that resolve_packages + a feature filter works.
         let feature_set = feature_graph.resolve_packages(

--- a/guppy/src/unit_tests/graph_tests.rs
+++ b/guppy/src/unit_tests/graph_tests.rs
@@ -30,9 +30,12 @@ mod small {
         assert_eq!(root_deps.len(), 1, "the root crate has one dependency");
         let dep = root_deps.pop().expect("the root crate has one dependency");
         // XXX test for details of dependency edges as well?
-        assert!(dep.edge.normal().is_some(), "normal dependency is defined");
-        assert!(dep.edge.build().is_some(), "build dependency is defined");
-        assert!(dep.edge.dev().is_some(), "dev dependency is defined");
+        assert!(
+            dep.edge.normal().is_present(),
+            "normal dependency is defined"
+        );
+        assert!(dep.edge.build().is_present(), "build dependency is defined");
+        assert!(dep.edge.dev().is_present(), "dev dependency is defined");
 
         // Print out dot graphs for small subgraphs.
         static EXPECTED_DOT: &str = r#"digraph {
@@ -187,24 +190,29 @@ mod small {
         let package_set = package_graph.resolve_all();
         let feature_graph = metadata_targets1.graph().feature_graph();
         assert_eq!(feature_graph.feature_count(), 31, "feature count");
-        for (source, target, edge) in feature_graph
-            .resolve_all()
-            .into_links(DependencyDirection::Forward)
-        {
-            let source_metadata = package_graph.metadata(source.package_id()).unwrap();
-            let target_metadata = package_graph.metadata(target.package_id()).unwrap();
 
-            println!(
-                "feature link: {}:{} {} -> {}:{} {} {:?}",
-                source_metadata.name(),
-                source_metadata.version(),
-                source.feature().unwrap_or("[base]"),
-                target_metadata.name(),
-                target_metadata.version(),
-                target.feature().unwrap_or("[base]"),
-                edge
-            );
+        // Some code that might be useful for debugging.
+        if false {
+            for (source, target, edge) in feature_graph
+                .resolve_all()
+                .into_links(DependencyDirection::Forward)
+            {
+                let source_metadata = package_graph.metadata(source.package_id()).unwrap();
+                let target_metadata = package_graph.metadata(target.package_id()).unwrap();
+
+                println!(
+                    "feature link: {}:{} {} -> {}:{} {} {:?}",
+                    source_metadata.name(),
+                    source_metadata.version(),
+                    source.feature().unwrap_or("[base]"),
+                    target_metadata.name(),
+                    target_metadata.version(),
+                    target.feature().unwrap_or("[base]"),
+                    edge
+                );
+            }
         }
+
         assert_eq!(feature_graph.link_count(), 48, "feature link count");
 
         // Check that resolve_packages + a feature filter works.


### PR DESCRIPTION
I've been a bit unsatisfied by the current design of the way `EnabledStatus` etc work.

* The current design always requires evaluation against a particular platform. We've made this easier by providing the current platform as default, but that is error-prone as #111 points out.
* The current design also doesn't have a way to distinguish between dependencies that are enabled regardless of platform and those that are enabled on a specific platform (but might be disabled on others).
* The API also isn't very orthogonal -- in particular, feature graph resolution caused me to have to introduce the `PlatformStatus` API anyway, and we should try and make that API also work for the package graph.

This new design is an answer to all of those concerns. It introduces three data structures:
* `EnabledStatus`, which is a pair of (required, optional) `PlatformStatus` instances.
* `PlatformStatus`, which is always, never or platform-dependent.
* `PlatformEval`, which represents a set of target specs to evaluate against a platform.

The API is also designed to provide information at the level of granularity one desires. For example, if one isn't interested in distinguishing between enabled-everywhere and enabled-on-platform, one can just call `PlatformStatus::enabled_on`. If that information is required, users can always match on the `PlatformStatus`.

This also cleans up many issues that were somewhat annoying to me -- for example, `cargo-guppy`'s `--include-target` flag only checked for the normal edge. With this commit, `cargo-guppy` combines  the `--include-target`, `--include-dev` and `--include-build` flags in a way that feels very natural.

Closes #110.
Closes #111.