### PR TITLE
[guppy] make resolve set iterators nonconsuming

### DIFF
--- a/benchmarks/benches/package_graph.rs
+++ b/benchmarks/benches/package_graph.rs
@@ -47,7 +47,7 @@ pub fn benchmarks(c: &mut Criterion) {
                         let query = package_graph
                             .query_directed(package_ids.iter().copied(), *query_direction)
                             .unwrap();
-                        let _: Vec<_> = query.resolve().into_ids(*iter_direction).collect();
+                        let _: Vec<_> = query.resolve().package_ids(*iter_direction).collect();
                     })
             },
             BatchSize::SmallInput,

--- a/cargo-guppy/src/lib.rs
+++ b/cargo-guppy/src/lib.rs
@@ -52,7 +52,7 @@ pub fn cmd_dups(filter_opts: &FilterOptions) -> Result<(), anyhow::Error> {
     let mut dupe_map: HashMap<_, Vec<_>> = HashMap::new();
     for package in selection
         .resolve_with_fn(resolver)
-        .into_metadatas(DependencyDirection::Forward)
+        .packages(DependencyDirection::Forward)
     {
         dupe_map.entry(package.name()).or_default().push(package);
     }
@@ -107,7 +107,7 @@ pub fn cmd_select(options: &CmdSelectOptions) -> Result<(), anyhow::Error> {
     let resolver = options.filter_opts.make_resolver(&pkg_graph);
     let package_set = query.resolve_with_fn(resolver);
 
-    for package_id in package_set.clone().into_ids(options.output_direction) {
+    for package_id in package_set.package_ids(options.output_direction) {
         let package = pkg_graph.metadata(package_id).unwrap();
         let in_workspace = package.in_workspace();
         let direct_dep = pkg_graph
@@ -171,12 +171,12 @@ pub fn cmd_subtree_size(options: &SubtreeSizeOptions) -> Result<(), anyhow::Erro
     let mut unique_deps: HashMap<&PackageId, HashSet<&PackageId>> = HashMap::new();
     for package_id in selection
         .resolve_with_fn(&resolver)
-        .into_ids(DependencyDirection::Forward)
+        .package_ids(DependencyDirection::Forward)
     {
         let subtree_package_set: HashSet<&PackageId> = pkg_graph
             .query_forward(iter::once(package_id))?
             .resolve_with_fn(&resolver)
-            .into_ids(DependencyDirection::Forward)
+            .package_ids(DependencyDirection::Forward)
             .collect();
         let mut nonunique_deps_set: HashSet<&PackageId> = HashSet::new();
         for dep_package_id in &subtree_package_set {

--- a/cargo-guppy/src/lib.rs
+++ b/cargo-guppy/src/lib.rs
@@ -126,7 +126,7 @@ pub fn cmd_select(options: &CmdSelectOptions) -> Result<(), anyhow::Error> {
     }
 
     if let Some(ref output_file) = options.output_dot {
-        let dot = package_set.into_dot(NameVisitor);
+        let dot = package_set.display_dot(NameVisitor);
         let mut f = fs::File::create(output_file)?;
         write!(f, "{}", dot)?;
     }

--- a/guppy/examples/deps.rs
+++ b/guppy/examples/deps.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Error> {
     // topological order.
     let query = package_graph.query_forward(iter::once(&package_id))?;
     let package_set = query.resolve();
-    for dep_id in package_set.into_ids(DependencyDirection::Forward) {
+    for dep_id in package_set.package_ids(DependencyDirection::Forward) {
         // PackageSet also has an `into_links()` method which returns links instead of IDs.
         println!("transitive: {}", dep_id);
     }

--- a/guppy/examples/deps.rs
+++ b/guppy/examples/deps.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Error> {
     let query = package_graph.query_forward(iter::once(&package_id))?;
     let package_set = query.resolve();
     for dep_id in package_set.package_ids(DependencyDirection::Forward) {
-        // PackageSet also has an `into_links()` method which returns links instead of IDs.
+        // PackageSet also has an `links()` method which returns links instead of package IDs.
         println!("transitive: {}", dep_id);
     }
     Ok(())

--- a/guppy/examples/print_dot.rs
+++ b/guppy/examples/print_dot.rs
@@ -49,8 +49,8 @@ fn main() -> Result<(), Error> {
     let query = package_graph.query_reverse(package_graph.workspace().member_ids())?;
     let package_set = query.resolve();
 
-    // resolve.into_dot() implements `std::fmt::Display`, so it can be written out to a file, a
+    // resolve.display_dot() implements `std::fmt::Display`, so it can be written out to a file, a
     // string, stdout, etc.
-    println!("{}", package_set.into_dot(PackageNameVisitor));
+    println!("{}", package_set.display_dot(PackageNameVisitor));
     Ok(())
 }

--- a/guppy/examples/remove_dev_only.rs
+++ b/guppy/examples/remove_dev_only.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Error> {
     let before_count = package_graph
         .query_forward(iter::once(&libra_node_id))?
         .resolve()
-        .into_ids(DependencyDirection::Forward)
+        .package_ids(DependencyDirection::Forward)
         .count();
     println!("number of packages before: {}", before_count);
 
@@ -57,7 +57,7 @@ fn main() -> Result<(), Error> {
             // used with `resolve_with_fn`.
             resolver_fn(link)
         })
-        .into_ids(DependencyDirection::Forward)
+        .package_ids(DependencyDirection::Forward)
         .len();
     println!("number of packages with resolve_with: {}", resolve_with_len);
 
@@ -80,7 +80,7 @@ fn main() -> Result<(), Error> {
     let after_count = package_graph
         .query_forward(iter::once(&libra_node_id))?
         .resolve()
-        .into_ids(DependencyDirection::Forward)
+        .package_ids(DependencyDirection::Forward)
         .count();
     println!("number of packages after retain_edges: {}", after_count);
 

--- a/guppy/examples/remove_dev_only.rs
+++ b/guppy/examples/remove_dev_only.rs
@@ -71,7 +71,7 @@ fn main() -> Result<(), Error> {
     // Iterate over all links and assert that there are no dev-only links.
     for link in package_graph
         .resolve_all()
-        .into_links(DependencyDirection::Forward)
+        .links(DependencyDirection::Forward)
     {
         assert!(!link.edge.dev_only());
     }

--- a/guppy/examples/topo_sort.rs
+++ b/guppy/examples/topo_sort.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Error> {
     let package_set = query.resolve();
 
     // Iterate over packages in forward topo order.
-    for package in package_set.into_metadatas(DependencyDirection::Forward) {
+    for package in package_set.packages(DependencyDirection::Forward) {
         // All selected packages are in the workspace.
         let workspace_path = package
             .workspace_path()

--- a/guppy/src/graph/feature/graph_impl.rs
+++ b/guppy/src/graph/feature/graph_impl.rs
@@ -428,7 +428,7 @@ impl FeatureGraphImpl {
 
         for link in package_graph
             .resolve_all()
-            .into_links(DependencyDirection::Reverse)
+            .links(DependencyDirection::Reverse)
         {
             build_state.add_dependency_edges(link);
         }

--- a/guppy/src/graph/feature/graph_impl.rs
+++ b/guppy/src/graph/feature/graph_impl.rs
@@ -421,7 +421,7 @@ impl FeatureGraphImpl {
         // The choice of bottom-up for this loop and the next is pretty arbitrary.
         for metadata in package_graph
             .resolve_all()
-            .into_metadatas(DependencyDirection::Reverse)
+            .packages(DependencyDirection::Reverse)
         {
             build_state.add_named_feature_edges(metadata);
         }

--- a/guppy/src/graph/feature/resolve.rs
+++ b/guppy/src/graph/feature/resolve.rs
@@ -281,10 +281,10 @@ impl<'g> FeatureSet<'g> {
     ///
     /// If a root consists of a dependency cycle, all the packages in it will be returned in
     /// arbitrary order.
-    pub fn into_root_ids(
-        self,
+    pub fn root_ids<'a>(
+        &'a self,
         direction: DependencyDirection,
-    ) -> impl Iterator<Item = FeatureId<'g>> + 'g {
+    ) -> impl Iterator<Item = FeatureId<'g>> + ExactSizeIterator + 'a {
         let dep_graph = self.graph.dep_graph();
         let package_graph = self.graph.package_graph;
         self.core
@@ -304,10 +304,10 @@ impl<'g> FeatureSet<'g> {
     ///
     /// If a root consists of a dependency cycle, all the packages in it will be returned in
     /// arbitrary order.}
-    pub fn into_root_metadatas(
-        self,
+    pub fn root_features<'a>(
+        &'a self,
         direction: DependencyDirection,
-    ) -> impl Iterator<Item = FeatureMetadata<'g>> + 'g {
+    ) -> impl Iterator<Item = FeatureMetadata<'g>> + 'a {
         let feature_graph = self.graph;
         self.core
             .roots(feature_graph.dep_graph(), feature_graph.sccs(), direction)

--- a/guppy/src/graph/feature/resolve.rs
+++ b/guppy/src/graph/feature/resolve.rs
@@ -241,10 +241,10 @@ impl<'g> FeatureSet<'g> {
     ///
     /// The packages within a dependency cycle will be returned in arbitrary order, but overall
     /// topological order will be maintained.
-    pub fn into_packages_with_features<B>(
-        self,
+    pub fn packages_with_features<'a, B>(
+        &'a self,
         direction: DependencyDirection,
-    ) -> impl Iterator<Item = (&'g PackageMetadata, B)> + 'g
+    ) -> impl Iterator<Item = (&'g PackageMetadata, B)> + 'a
     where
         B: FromIterator<Option<&'g str>>,
     {

--- a/guppy/src/graph/feature/resolve.rs
+++ b/guppy/src/graph/feature/resolve.rs
@@ -345,10 +345,10 @@ impl<'g> FeatureSet<'g> {
 
     // Currently a helper for debugging -- will be made public in the future.
     #[allow(dead_code)]
-    pub(crate) fn into_links(
-        self,
+    pub(crate) fn links<'a>(
+        &'a self,
         direction: DependencyDirection,
-    ) -> impl Iterator<Item = (FeatureId<'g>, FeatureId<'g>, &'g FeatureEdge)> {
+    ) -> impl Iterator<Item = (FeatureId<'g>, FeatureId<'g>, &'g FeatureEdge)> + 'a {
         let feature_graph = self.graph;
 
         self.core

--- a/guppy/src/graph/resolve.rs
+++ b/guppy/src/graph/resolve.rs
@@ -214,10 +214,10 @@ impl<'g> PackageSet<'g> {
     ///
     /// If a root consists of a dependency cycle, all the packages in it will be returned in
     /// arbitrary order.
-    pub fn into_root_ids(
-        self,
+    pub fn root_ids<'a>(
+        &'a self,
         direction: DependencyDirection,
-    ) -> impl Iterator<Item = &'g PackageId> + ExactSizeIterator + 'g {
+    ) -> impl Iterator<Item = &'g PackageId> + ExactSizeIterator + 'a {
         let dep_graph = &self.graph.dep_graph;
         self.core
             .roots(self.graph.dep_graph(), self.graph.sccs(), direction)
@@ -236,10 +236,10 @@ impl<'g> PackageSet<'g> {
     ///
     /// If a root consists of a dependency cycle, all the packages in it will be returned in
     /// arbitrary order.
-    pub fn into_root_metadatas(
-        self,
+    pub fn root_packages<'a>(
+        &'a self,
         direction: DependencyDirection,
-    ) -> impl Iterator<Item = &'g PackageMetadata> + ExactSizeIterator + 'g {
+    ) -> impl Iterator<Item = &'g PackageMetadata> + ExactSizeIterator + 'a {
         let package_graph = self.graph;
         self.core
             .roots(self.graph.dep_graph(), self.graph.sccs(), direction)

--- a/guppy/src/graph/resolve_core.rs
+++ b/guppy/src/graph/resolve_core.rs
@@ -148,7 +148,11 @@ impl<G: GraphSpec> ResolveCore<G> {
         }
     }
 
-    pub(super) fn topo(self, sccs: &Sccs<G::Ix>, direction: DependencyDirection) -> Topo<G> {
+    pub(super) fn topo<'g>(
+        &'g self,
+        sccs: &'g Sccs<G::Ix>,
+        direction: DependencyDirection,
+    ) -> Topo<'g, G> {
         // ---
         // IMPORTANT
         // ---
@@ -170,7 +174,7 @@ impl<G: GraphSpec> ResolveCore<G> {
 
         Topo {
             node_iter,
-            included: self.included,
+            included: &self.included,
             remaining: self.len,
         }
     }
@@ -209,15 +213,8 @@ impl<G: GraphSpec> ResolveCore<G> {
 #[derive(Clone, Debug)]
 pub(super) struct Topo<'g, G: GraphSpec> {
     node_iter: NodeIter<'g, G::Ix>,
-    included: FixedBitSet,
+    included: &'g FixedBitSet,
     remaining: usize,
-}
-
-impl<'g, G: GraphSpec> Topo<'g, G> {
-    /// Returns the direction the iteration is happening in.
-    pub fn direction(&self) -> DependencyDirection {
-        self.node_iter.direction().into()
-    }
 }
 
 impl<'g, G: GraphSpec> Iterator for Topo<'g, G> {

--- a/guppy/src/petgraph_support/scc.rs
+++ b/guppy/src/petgraph_support/scc.rs
@@ -122,6 +122,7 @@ pub(crate) struct NodeIter<'a, Ix> {
 
 impl<'a, Ix> NodeIter<'a, Ix> {
     /// Returns the direction this iteration is happening in.
+    #[allow(dead_code)]
     pub fn direction(&self) -> Direction {
         self.direction
     }

--- a/guppy/src/unit_tests/dep_helpers.rs
+++ b/guppy/src/unit_tests/dep_helpers.rs
@@ -195,7 +195,7 @@ pub(crate) fn assert_transitive_deps_internal(
     // up at least once in 'to' before it ever shows up in 'from'.
     assert_link_order(
         actual_deps,
-        package_set.clone().into_root_ids(direction),
+        package_set.root_ids(direction),
         desc,
         &format!("{}: actual link order", msg),
     );
@@ -215,7 +215,7 @@ pub(crate) fn assert_transitive_deps_internal(
 
     assert_link_order(
         opposite_deps,
-        package_set.clone().into_root_ids(opposite),
+        package_set.root_ids(opposite),
         opposite_desc,
         &format!("{}: opposite link order", msg),
     );
@@ -338,7 +338,7 @@ pub(crate) fn assert_all_links(graph: &PackageGraph, direction: DependencyDirect
     // all_links should be in the correct order.
     assert_link_order(
         all_links,
-        graph.resolve_all().into_root_ids(direction),
+        graph.resolve_all().root_ids(direction),
         desc,
         msg,
     );
@@ -597,8 +597,8 @@ pub(super) trait GraphSet<'g>: Clone + fmt::Debug {
 
     fn ids(&self, direction: DependencyDirection) -> Vec<Self::Id>;
     fn metadatas(&self, direction: DependencyDirection) -> Vec<Self::Metadata>;
-    fn root_ids(self, direction: DependencyDirection) -> Vec<Self::Id>;
-    fn root_metadatas(self, direction: DependencyDirection) -> Vec<Self::Metadata>;
+    fn root_ids(&self, direction: DependencyDirection) -> Vec<Self::Id>;
+    fn root_metadatas(&self, direction: DependencyDirection) -> Vec<Self::Metadata>;
 }
 
 impl<'g> GraphAssert<'g> for &'g PackageGraph {
@@ -691,12 +691,12 @@ impl<'g> GraphSet<'g> for PackageSet<'g> {
         self.packages(direction).collect()
     }
 
-    fn root_ids(self, direction: DependencyDirection) -> Vec<Self::Id> {
-        self.into_root_ids(direction).collect()
+    fn root_ids(&self, direction: DependencyDirection) -> Vec<Self::Id> {
+        Self::root_ids(self, direction).collect()
     }
 
-    fn root_metadatas(self, direction: DependencyDirection) -> Vec<Self::Metadata> {
-        self.into_root_metadatas(direction).collect()
+    fn root_metadatas(&self, direction: DependencyDirection) -> Vec<Self::Metadata> {
+        Self::root_packages(self, direction).collect()
     }
 }
 
@@ -790,12 +790,12 @@ impl<'g> GraphSet<'g> for FeatureSet<'g> {
         self.features(direction).collect()
     }
 
-    fn root_ids(self, direction: DependencyDirection) -> Vec<Self::Id> {
-        self.into_root_ids(direction).collect()
+    fn root_ids(&self, direction: DependencyDirection) -> Vec<Self::Id> {
+        Self::root_ids(self, direction).collect()
     }
 
-    fn root_metadatas(self, direction: DependencyDirection) -> Vec<Self::Metadata> {
-        self.into_root_metadatas(direction).collect()
+    fn root_metadatas(&self, direction: DependencyDirection) -> Vec<Self::Metadata> {
+        Self::root_features(self, direction).collect()
     }
 }
 

--- a/guppy/src/unit_tests/dep_helpers.rs
+++ b/guppy/src/unit_tests/dep_helpers.rs
@@ -166,7 +166,7 @@ pub(crate) fn assert_transitive_deps_internal(
     let mut actual_dep_ids: Vec<_> = package_ids.collect();
     actual_dep_ids.sort();
 
-    let actual_deps: Vec<_> = package_set.clone().into_links(direction).collect();
+    let actual_deps: Vec<_> = package_set.links(direction).collect();
     let actual_ptrs = dep_link_ptrs(actual_deps.iter().copied());
 
     // Use a BTreeSet for unique identifiers. This is also used later for set operations.
@@ -203,7 +203,7 @@ pub(crate) fn assert_transitive_deps_internal(
     // Do a query in the opposite direction as well to test link order.
     let opposite = direction.opposite();
     let opposite_desc = DirectionDesc::new(opposite);
-    let opposite_deps: Vec<_> = package_set.clone().into_links(opposite).collect();
+    let opposite_deps: Vec<_> = package_set.links(opposite).collect();
     let opposite_ptrs = dep_link_ptrs(opposite_deps.iter().copied());
 
     // Checking for pointer equivalence is enough since they both use the same graph as a base.
@@ -256,7 +256,7 @@ pub(crate) fn assert_transitive_deps_internal(
                 )
             })
             .resolve()
-            .into_links(direction)
+            .links(direction)
             .flat_map(|dep| vec![dep.from.id(), dep.to.id()])
             .collect();
         // Use difference instead of is_subset/is_superset for better error messages.
@@ -307,7 +307,7 @@ pub(crate) fn assert_topo_metadatas(
 
 pub(crate) fn assert_all_links(graph: &PackageGraph, direction: DependencyDirection, msg: &str) {
     let desc = DirectionDesc::new(direction);
-    let all_links: Vec<_> = graph.resolve_all().into_links(direction).collect();
+    let all_links: Vec<_> = graph.resolve_all().links(direction).collect();
     assert_eq!(
         all_links.len(),
         graph.link_count(),

--- a/guppy/src/unit_tests/graph_tests.rs
+++ b/guppy/src/unit_tests/graph_tests.rs
@@ -57,16 +57,15 @@ mod small {
     26 -> 13 [label="winapi"]
 }
 "#;
-        let actual_dot = graph
+        let package_set = graph
             .query_forward(iter::once(&fixtures::package_id(
                 fixtures::METADATA1_REGION,
             )))
             .unwrap()
-            .resolve()
-            .into_dot(NameVisitor);
+            .resolve();
         assert_eq!(
             EXPECTED_DOT,
-            format!("{}", actual_dot),
+            format!("{}", package_set.display_dot(NameVisitor)),
             "dot output matches"
         );
 
@@ -81,15 +80,14 @@ mod small {
     18 -> 1 [label="datatest"]
 }
 "#;
-        let actual_dot_reversed = graph
+        let package_set = graph
             .query_reverse(iter::once(&fixtures::package_id(fixtures::METADATA1_DTOA)))
             .unwrap()
-            .resolve()
-            .into_dot(NameVisitor);
+            .resolve();
 
         assert_eq!(
             EXPECTED_DOT_REVERSED,
-            format!("{}", actual_dot_reversed),
+            format!("{}", package_set.display_dot(NameVisitor)),
             "reversed dot output matches"
         );
 
@@ -110,16 +108,15 @@ mod small {
     26 -> 13 [label="winapi"]
 }
 "#;
-        let actual_dot = graph
+        let package_set = graph
             .query_forward(iter::once(&fixtures::package_id(
                 fixtures::METADATA1_REGION,
             )))
             .unwrap()
-            .resolve_with_fn(|_, link| link.to.name() != "libc")
-            .into_dot(NameVisitor);
+            .resolve_with_fn(|_, link| link.to.name() != "libc");
         assert_eq!(
             EXPECTED_DOT_NO_LIBC,
-            format!("{}", actual_dot),
+            format!("{}", package_set.display_dot(NameVisitor)),
             "dot output matches"
         );
 

--- a/guppy/src/unit_tests/graph_tests.rs
+++ b/guppy/src/unit_tests/graph_tests.rs
@@ -195,7 +195,7 @@ mod small {
         if false {
             for (source, target, edge) in feature_graph
                 .resolve_all()
-                .into_links(DependencyDirection::Forward)
+                .links(DependencyDirection::Forward)
             {
                 let source_metadata = package_graph.metadata(source.package_id()).unwrap();
                 let target_metadata = package_graph.metadata(target.package_id()).unwrap();
@@ -372,7 +372,7 @@ mod large {
 
         let mut build_dep_but_no_build_script: Vec<_> = graph
             .resolve_all()
-            .into_links(DependencyDirection::Forward)
+            .links(DependencyDirection::Forward)
             .filter_map(|link| {
                 if link.edge.build().is_present() && !link.from.has_build_script() {
                     Some(link.from.name())

--- a/guppy/src/unit_tests/graph_tests.rs
+++ b/guppy/src/unit_tests/graph_tests.rs
@@ -129,9 +129,7 @@ mod small {
         assert_eq!(feature_graph.feature_count(), 492, "feature count");
         assert_eq!(feature_graph.link_count(), 609, "link count");
         let feature_set = feature_graph.query_workspace(all_filter()).resolve();
-        let root_ids: Vec<_> = feature_set
-            .into_root_ids(DependencyDirection::Forward)
-            .collect();
+        let root_ids: Vec<_> = feature_set.root_ids(DependencyDirection::Forward).collect();
         let testcrate_id = fixtures::package_id(fixtures::METADATA1_TESTCRATE);
         let expected = vec![FeatureId::new(&testcrate_id, "datatest")];
         assert_eq!(root_ids, expected, "feature graph root IDs match");
@@ -150,7 +148,7 @@ mod small {
         let root_ids: Vec<_> = feature_graph
             .query_workspace(none_filter())
             .resolve()
-            .into_root_ids(DependencyDirection::Forward)
+            .root_ids(DependencyDirection::Forward)
             .collect();
         let testcrate_id = fixtures::package_id(fixtures::METADATA2_TESTCRATE);
         let expected = vec![FeatureId::base(&testcrate_id)];

--- a/guppy/src/unit_tests/proptest_helpers.rs
+++ b/guppy/src/unit_tests/proptest_helpers.rs
@@ -600,8 +600,7 @@ pub(super) fn feature_set_props(feature_set: FeatureSet<'_>, direction: Dependen
     // into_ids and into_packages_with_features match (after sorting).
     let mut feature_ids: Vec<_> = feature_set.feature_ids(direction).collect();
     let mut feature_ids_2: Vec<_> = feature_set
-        .clone()
-        .into_packages_with_features(direction)
+        .packages_with_features(direction)
         .flat_map(|(metadata, features): (_, Vec<_>)| {
             let package_id = metadata.id();
             features
@@ -623,7 +622,7 @@ pub(super) fn feature_set_props(feature_set: FeatureSet<'_>, direction: Dependen
         .package_ids(direction)
         .collect();
     let feature_set_ids: Vec<_> = feature_set
-        .into_packages_with_features(direction)
+        .packages_with_features(direction)
         .map(|(metadata, features): (_, Vec<_>)| {
             println!("for id {}, features: {:?}", metadata.id(), features);
             metadata.id()

--- a/guppy/src/unit_tests/proptest_helpers.rs
+++ b/guppy/src/unit_tests/proptest_helpers.rs
@@ -396,7 +396,7 @@ pub(super) fn resolver_retain_equivalence(
         .query_directed(ids.iter().copied(), direction)
         .unwrap()
         .resolve_with(&mut resolver)
-        .into_ids(direction)
+        .package_ids(direction)
         // Clone to release borrow on the graph.
         .cloned()
         .collect();
@@ -411,7 +411,7 @@ pub(super) fn resolver_retain_equivalence(
         .query_directed(ids.iter().copied(), direction)
         .unwrap()
         .resolve()
-        .into_ids(direction)
+        .package_ids(direction)
         // Clone because PartialEq isn't implemented for &PackageId and PackageId :/ sigh.
         .cloned()
         .collect();
@@ -517,7 +517,7 @@ fn resolve_ops_impl<G: GraphAssert<'static>>(
             direction,
         } => {
             let resolve_set = graph.resolve(&initials, *direction);
-            let ids = resolve_set.clone().ids(*direction).into_iter().collect();
+            let ids = resolve_set.ids(*direction).into_iter().collect();
             (resolve_set, ids)
         }
         ResolveTree::Union(a, b) => {
@@ -594,15 +594,15 @@ pub(super) fn package_feature_set_roundtrip(
         );
     }
 
-    let package_ids: Vec<_> = package_set.into_ids(test_direction).collect();
+    let package_ids: Vec<_> = package_set.package_ids(test_direction).collect();
     let package_set_2 = all_feature_set.to_package_set();
-    let package_ids_2: Vec<_> = package_set_2.into_ids(test_direction).collect();
+    let package_ids_2: Vec<_> = package_set_2.package_ids(test_direction).collect();
     assert_eq!(package_ids, package_ids_2, "package IDs roundtrip");
 }
 
 pub(super) fn feature_set_props(feature_set: FeatureSet<'_>, direction: DependencyDirection) {
     // into_ids and into_packages_with_features match (after sorting).
-    let mut feature_ids: Vec<_> = feature_set.clone().into_ids(direction).collect();
+    let mut feature_ids: Vec<_> = feature_set.feature_ids(direction).collect();
     let mut feature_ids_2: Vec<_> = feature_set
         .clone()
         .into_packages_with_features(direction)
@@ -622,7 +622,10 @@ pub(super) fn feature_set_props(feature_set: FeatureSet<'_>, direction: Dependen
     );
 
     // to_package_set and into_packages_with_features match (without sorting).
-    let package_set_ids: Vec<_> = feature_set.to_package_set().into_ids(direction).collect();
+    let package_set_ids: Vec<_> = feature_set
+        .to_package_set()
+        .package_ids(direction)
+        .collect();
     let feature_set_ids: Vec<_> = feature_set
         .into_packages_with_features(direction)
         .map(|(metadata, features): (_, Vec<_>)| {

--- a/guppy/src/unit_tests/proptest_helpers.rs
+++ b/guppy/src/unit_tests/proptest_helpers.rs
@@ -319,11 +319,7 @@ pub(super) fn link_order(
     // well. Compute the root IDs from the graph in that case.
     let has_cycles = graph.cycles().all_cycles().count() > 0;
     let initials = if has_cycles || query_direction != iter_direction {
-        query
-            .clone()
-            .resolve()
-            .into_root_ids(iter_direction)
-            .collect()
+        query.clone().resolve().root_ids(iter_direction).collect()
     } else {
         ids.to_vec()
     };

--- a/guppy/src/unit_tests/proptest_helpers.rs
+++ b/guppy/src/unit_tests/proptest_helpers.rs
@@ -311,19 +311,20 @@ pub(super) fn link_order(
     iter_direction: DependencyDirection,
     msg: &str,
 ) {
-    let query = graph
+    let package_set = graph
         .query_directed(ids.iter().copied(), query_direction)
-        .unwrap();
+        .unwrap()
+        .resolve();
     // If the query and iter directions are the same, the set of initial IDs may be expanded
     // in case of cycles. If they are the opposite, the set of initial IDs will be different as
     // well. Compute the root IDs from the graph in that case.
     let has_cycles = graph.cycles().all_cycles().count() > 0;
     let initials = if has_cycles || query_direction != iter_direction {
-        query.clone().resolve().root_ids(iter_direction).collect()
+        package_set.root_ids(iter_direction).collect()
     } else {
         ids.to_vec()
     };
-    let links = query.resolve().into_links(iter_direction);
+    let links = package_set.links(iter_direction);
     assert_link_order(
         links,
         initials,
@@ -332,7 +333,7 @@ pub(super) fn link_order(
     );
 }
 
-/// Test that the results of an `into_root_ids` query don't depend on any other root.
+/// Test that the results of an `root_ids` query don't depend on any other root.
 pub(super) fn roots<'g, G: GraphAssert<'g>>(
     graph: G,
     ids: &[G::Id],


### PR DESCRIPTION
These started off as consuming when we didn't have resolve sets as a first-class concept, but they no longer need to be.