### PR TITLE
[graph] remove PackageEdge, subsume its functionality into PackageLink

### DIFF
--- a/cargo-guppy/src/lib.rs
+++ b/cargo-guppy/src/lib.rs
@@ -113,7 +113,7 @@ pub fn cmd_select(options: &CmdSelectOptions) -> Result<(), anyhow::Error> {
         let direct_dep = pkg_graph
             .reverse_dep_links(package_id)
             .unwrap()
-            .any(|l| l.from.in_workspace() && !l.to.in_workspace());
+            .any(|link| link.from().in_workspace() && !link.to().in_workspace());
         let show_package = match options.filter_opts.kind {
             Kind::All => true,
             Kind::Workspace => in_workspace,
@@ -186,18 +186,17 @@ pub fn cmd_subtree_size(options: &SubtreeSizeOptions) -> Result<(), anyhow::Erro
             }
 
             let mut unique = true;
-            for reverse_dep_link in pkg_graph.reverse_dep_links(dep_package_id).unwrap() {
+            for link in pkg_graph.reverse_dep_links(dep_package_id).unwrap() {
                 // skip build and dev dependencies
-                if reverse_dep_link.edge.dev_only() {
+                if link.dev_only() {
                     continue;
                 }
+                let from_id = link.from().id();
 
-                if !subtree_package_set.contains(reverse_dep_link.from.id())
-                    || nonunique_deps_set.contains(reverse_dep_link.from.id())
-                {
+                if !subtree_package_set.contains(from_id) || nonunique_deps_set.contains(from_id) {
                     // if the from is from outside the subtree rooted at root_id, we ignore it
                     if let Some(root_id) = root_id {
-                        if !dep_cache.depends_on(root_id, reverse_dep_link.from.id())? {
+                        if !dep_cache.depends_on(root_id, from_id)? {
                             continue;
                         }
                     }

--- a/guppy/README.md
+++ b/guppy/README.md
@@ -35,9 +35,9 @@ let package_id = PackageId::new("testcrate 0.1.0 (path+file:///fakepath/testcrat
 // dep_links returns all direct dependencies of a package, and it returns `None` if the package
 // ID isn't recognized.
 for link in package_graph.dep_links(&package_id).unwrap() {
-    // A dependency link contains `from`, `to` and `edge`. The edge has information about e.g.
-    // whether this is a build dependency.
-    println!("direct dependency: {}", link.to.id());
+    // A dependency link contains `from()`, `to()` and information about the specifics of the
+    // dependency.
+    println!("direct dependency: {}", link.to().id());
 }
 ```
 

--- a/guppy/examples/deps.rs
+++ b/guppy/examples/deps.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Error> {
     for link in package_graph.dep_links(&package_id).unwrap() {
         // A dependency link contains `from`, `to` and `edge`. The edge has information about e.g.
         // whether this is a build dependency.
-        println!("direct: {}", link.to.id());
+        println!("direct: {}", link.to().id());
     }
 
     // Transitive dependencies are obtained through the `query_` APIs. They are always presented in

--- a/guppy/examples/print_by_level.rs
+++ b/guppy/examples/print_by_level.rs
@@ -52,9 +52,10 @@ fn main() -> Result<(), Error> {
                 // we want to collect all of them together.
                 let links = package_graph.dep_links(id).expect("ID is");
                 links.map(|link| {
+                    let to = link.to();
                     // Since we're iterating over transitive dependencies, we use the 'to' ID here.
                     // If we were iterating over transitive reverse deps, we'd use the 'from' ID.
-                    (link.to.id(), link.to)
+                    (to.id(), to)
                 })
             })
             .collect();

--- a/guppy/examples/print_dot.rs
+++ b/guppy/examples/print_dot.rs
@@ -30,7 +30,7 @@ impl PackageDotVisitor for PackageNameVisitor {
     }
 
     fn visit_link(&self, link: PackageLink<'_>, f: &mut DotWrite<'_, '_>) -> fmt::Result {
-        if link.edge.dev_only() {
+        if link.dev_only() {
             write!(f, "dev-only")
         } else {
             // Don't print out anything if this isn't a dev-only link.

--- a/guppy/examples/remove_dev_only.rs
+++ b/guppy/examples/remove_dev_only.rs
@@ -34,11 +34,11 @@ fn main() -> Result<(), Error> {
     println!("number of packages before: {}", before_count);
 
     let resolver_fn = |link: PackageLink<'_>| {
-        if link.edge.dev_only() {
+        if link.dev_only() {
             println!(
                 "*** filtering out dev-only link: {} -> {}",
-                link.from.name(),
-                link.to.name()
+                link.from().name(),
+                link.to().name()
             );
             return false;
         }
@@ -73,7 +73,7 @@ fn main() -> Result<(), Error> {
         .resolve_all()
         .links(DependencyDirection::Forward)
     {
-        assert!(!link.edge.dev_only());
+        assert!(!link.dev_only());
     }
 
     // Count the number of packages after.

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -3,8 +3,8 @@
 
 use crate::graph::{
     cargo_version_matches, BuildTargetImpl, BuildTargetKindImpl, DepRequiredOrOptional,
-    DependencyReqImpl, OwnedBuildTargetId, PackageEdgeImpl, PackageGraph, PackageGraphData,
-    PackageIx, PackageMetadata, PlatformStatusImpl, WorkspaceImpl,
+    DependencyReqImpl, OwnedBuildTargetId, PackageGraph, PackageGraphData, PackageIx,
+    PackageLinkImpl, PackageMetadata, PlatformStatusImpl, WorkspaceImpl,
 };
 use crate::sorted_set::SortedSet;
 use crate::{Error, Metadata, PackageId};
@@ -115,7 +115,7 @@ impl WorkspaceImpl {
 
 /// Helper struct for building up dependency graph.
 struct GraphBuildState<'a> {
-    dep_graph: Graph<PackageId, PackageEdgeImpl, Directed, PackageIx>,
+    dep_graph: Graph<PackageId, PackageLinkImpl, Directed, PackageIx>,
     // The values of package_data are (package_ix, name, version).
     package_data: HashMap<PackageId, (NodeIndex<PackageIx>, String, Version)>,
     resolve_data: HashMap<PackageId, (Vec<NodeDep>, Vec<String>)>,
@@ -201,7 +201,7 @@ impl<'a> GraphBuildState<'a> {
             let dep_id = PackageId::from_metadata(pkg.clone());
             let (name, deps) = dep_resolver.resolve(resolved_name, &dep_id)?;
             let (dep_idx, _, _) = self.package_data(&dep_id)?;
-            let edge = PackageEdgeImpl::new(&package_id, name, resolved_name, deps)?;
+            let edge = PackageLinkImpl::new(&package_id, name, resolved_name, deps)?;
             // Use update_edge instead of add_edge to prevent multiple edges from being added
             // between these two nodes.
             // XXX maybe check for an existing edge?
@@ -306,7 +306,7 @@ impl<'a> GraphBuildState<'a> {
         Ok(workspace_path.to_path_buf().into_boxed_path())
     }
 
-    fn finish(self) -> Graph<PackageId, PackageEdgeImpl, Directed, PackageIx> {
+    fn finish(self) -> Graph<PackageId, PackageLinkImpl, Directed, PackageIx> {
         self.dep_graph
     }
 }
@@ -585,7 +585,7 @@ impl<'g> DependencyReqs<'g> {
     }
 }
 
-impl PackageEdgeImpl {
+impl PackageLinkImpl {
     fn new<'a>(
         from_id: &PackageId,
         name: &str,

--- a/guppy/src/graph/mod.rs
+++ b/guppy/src/graph/mod.rs
@@ -124,7 +124,7 @@ trait GraphSpec {
 
 impl GraphSpec for PackageGraph {
     type Node = PackageId;
-    type Edge = PackageEdgeImpl;
+    type Edge = PackageLinkImpl;
     type Ix = PackageIx;
 }
 

--- a/guppy/src/graph/proptest09.rs
+++ b/guppy/src/graph/proptest09.rs
@@ -92,7 +92,7 @@ impl Prop09Resolver {
 
     /// Returns true if the given link is accepted by this resolver.
     pub fn accept_link(&self, link: PackageLink<'_>) -> bool {
-        self.included_edges.is_visited(&link.edge.edge_ix())
+        self.included_edges.is_visited(&link.edge_ix())
     }
 }
 
@@ -102,11 +102,11 @@ impl<'g> PackageResolver<'g> for Prop09Resolver {
             assert!(
                 query
                     .graph()
-                    .depends_on(link.from.id(), link.to.id())
+                    .depends_on(link.from().id(), link.to().id())
                     .expect("valid package IDs"),
                 "package '{}' should depend on '{}'",
-                link.from.id(),
-                link.to.id()
+                link.from().id(),
+                link.to().id()
             );
         }
 

--- a/guppy/src/graph/resolve.rs
+++ b/guppy/src/graph/resolve.rs
@@ -3,7 +3,7 @@
 
 use crate::graph::resolve_core::{ResolveCore, Topo};
 use crate::graph::{
-    DependencyDirection, PackageEdgeImpl, PackageGraph, PackageIx, PackageLink, PackageMetadata,
+    DependencyDirection, PackageGraph, PackageIx, PackageLink, PackageLinkImpl, PackageMetadata,
     PackageQuery,
 };
 use crate::petgraph_support::dot::{DotFmt, DotVisitor, DotWrite};
@@ -360,7 +360,7 @@ where
     ER: MaybeReversedEdge<
         NodeId = NodeIndex<PackageIx>,
         EdgeId = EdgeIndex<PackageIx>,
-        Weight = PackageEdgeImpl,
+        Weight = PackageLinkImpl,
     >,
 {
     fn visit_node(&self, node: NR, f: &mut DotWrite<'_, '_>) -> fmt::Result {

--- a/guppy/src/lib.rs
+++ b/guppy/src/lib.rs
@@ -34,9 +34,9 @@
 //! // dep_links returns all direct dependencies of a package, and it returns `None` if the package
 //! // ID isn't recognized.
 //! for link in package_graph.dep_links(&package_id).unwrap() {
-//!     // A dependency link contains `from`, `to` and `edge`. The edge has information about e.g.
-//!     // whether this is a build dependency.
-//!     println!("direct dependency: {}", link.to.id());
+//!     // A dependency link contains `from()`, `to()` and information about the specifics of the
+//!     // dependency.
+//!     println!("direct dependency: {}", link.to().id());
 //! }
 //! ```
 //!

--- a/guppy/src/unit_tests/graph_tests.rs
+++ b/guppy/src/unit_tests/graph_tests.rs
@@ -30,14 +30,11 @@ mod small {
             .collect();
 
         assert_eq!(root_deps.len(), 1, "the root crate has one dependency");
-        let dep = root_deps.pop().expect("the root crate has one dependency");
+        let link = root_deps.pop().expect("the root crate has one dependency");
         // XXX test for details of dependency edges as well?
-        assert!(
-            dep.edge.normal().is_present(),
-            "normal dependency is defined"
-        );
-        assert!(dep.edge.build().is_present(), "build dependency is defined");
-        assert!(dep.edge.dev().is_present(), "dev dependency is defined");
+        assert!(link.normal().is_present(), "normal dependency is defined");
+        assert!(link.build().is_present(), "build dependency is defined");
+        assert!(link.dev().is_present(), "dev dependency is defined");
 
         // Print out dot graphs for small subgraphs.
         static EXPECTED_DOT: &str = r#"digraph {
@@ -113,7 +110,7 @@ mod small {
                 fixtures::METADATA1_REGION,
             )))
             .unwrap()
-            .resolve_with_fn(|_, link| link.to.name() != "libc");
+            .resolve_with_fn(|_, link| link.to().name() != "libc");
         assert_eq!(
             EXPECTED_DOT_NO_LIBC,
             format!("{}", package_set.display_dot(NameVisitor)),
@@ -371,8 +368,8 @@ mod large {
             .resolve_all()
             .links(DependencyDirection::Forward)
             .filter_map(|link| {
-                if link.edge.build().is_present() && !link.from.has_build_script() {
-                    Some(link.from.name())
+                if link.build().is_present() && !link.from().has_build_script() {
+                    Some(link.from().name())
                 } else {
                     None
                 }
@@ -397,6 +394,6 @@ impl PackageDotVisitor for NameVisitor {
     }
 
     fn visit_link(&self, link: PackageLink<'_>, f: &mut DotWrite<'_, '_>) -> fmt::Result {
-        write!(f, "{}", link.edge.dep_name())
+        write!(f, "{}", link.dep_name())
     }
 }


### PR DESCRIPTION
The link/edge distinction made more sense in a world where we were returning
references directly, but now we return wrapper structs.