### PR TITLE
remove retain_edges, move direct dependency queries to PackageMetadata

### DIFF
--- a/cargo-guppy/src/diff.rs
+++ b/cargo-guppy/src/diff.rs
@@ -12,8 +12,8 @@ pub struct DiffOptions;
 impl DiffOptions {
     pub fn diff<'a>(
         &self,
-        old_packages: &[&'a PackageMetadata],
-        new_packages: &[&'a PackageMetadata],
+        old_packages: &'a [PackageMetadata<'a>],
+        new_packages: &'a [PackageMetadata<'a>],
     ) -> Diff<'a> {
         let mut new: HashMap<&PackageId, Package> =
             new_packages.iter().map(|p| (p.id(), Package(p))).collect();
@@ -114,10 +114,10 @@ impl DiffOptions {
 }
 
 #[derive(Clone, Debug)]
-struct Package<'a>(pub &'a PackageMetadata);
+struct Package<'a>(pub &'a PackageMetadata<'a>);
 
 impl<'a> Deref for Package<'a> {
-    type Target = PackageMetadata;
+    type Target = PackageMetadata<'a>;
 
     fn deref(&self) -> &Self::Target {
         self.0

--- a/cargo-guppy/src/lib.rs
+++ b/cargo-guppy/src/lib.rs
@@ -73,7 +73,7 @@ pub fn cmd_dups(filter_opts: &FilterOptions) -> Result<(), anyhow::Error> {
 struct NameVisitor;
 
 impl PackageDotVisitor for NameVisitor {
-    fn visit_package(&self, package: &PackageMetadata, f: &mut DotWrite<'_, '_>) -> fmt::Result {
+    fn visit_package(&self, package: PackageMetadata<'_>, f: &mut DotWrite<'_, '_>) -> fmt::Result {
         write!(f, "{}", package.name())
     }
 

--- a/guppy/README.md
+++ b/guppy/README.md
@@ -32,9 +32,13 @@ let package_graph = PackageGraph::from_json(fixture).unwrap();
 // `guppy` provides several ways to get hold of package IDs. Use a pre-defined one for this
 // example.
 let package_id = PackageId::new("testcrate 0.1.0 (path+file:///fakepath/testcrate)");
-// dep_links returns all direct dependencies of a package, and it returns `None` if the package
-// ID isn't recognized.
-for link in package_graph.dep_links(&package_id).unwrap() {
+
+// The `metadata` method returns information about the package, or `None` if the package ID
+// wasn't recognized.
+let package = package_graph.metadata(&package_id).unwrap();
+
+// `direct_links` returns all direct dependencies of a package.
+for link in package.direct_links() {
     // A dependency link contains `from()`, `to()` and information about the specifics of the
     // dependency.
     println!("direct dependency: {}", link.to().id());

--- a/guppy/examples/deps.rs
+++ b/guppy/examples/deps.rs
@@ -16,9 +16,12 @@ fn main() -> Result<(), Error> {
     // example.
     let package_id = PackageId::new("testcrate 0.1.0 (path+file:///fakepath/testcrate)");
 
-    // dep_links returns all direct dependencies of a package, and it returns `None` if the package
-    // ID isn't recognized.
-    for link in package_graph.dep_links(&package_id).unwrap() {
+    // The `metadata` method returns information about the package, or `None` if the package ID
+    // wasn't recognized.
+    let package = package_graph.metadata(&package_id).unwrap();
+
+    // `direct_links` returns all direct dependencies of a package.
+    for link in package.direct_links() {
         // A dependency link contains `from`, `to` and `edge`. The edge has information about e.g.
         // whether this is a build dependency.
         println!("direct: {}", link.to().id());

--- a/guppy/examples/print_by_level.rs
+++ b/guppy/examples/print_by_level.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Error> {
             .flat_map(|(id, _)| {
                 // This is a flat_map because each package in current has multiple dependencies, and
                 // we want to collect all of them together.
-                let links = package_graph.dep_links(id).expect("ID is");
+                let links = package_graph.metadata(id).expect("valid ID").direct_links();
                 links.map(|link| {
                     let to = link.to();
                     // Since we're iterating over transitive dependencies, we use the 'to' ID here.

--- a/guppy/examples/print_dot.rs
+++ b/guppy/examples/print_dot.rs
@@ -21,7 +21,7 @@ use std::fmt;
 struct PackageNameVisitor;
 
 impl PackageDotVisitor for PackageNameVisitor {
-    fn visit_package(&self, package: &PackageMetadata, f: &mut DotWrite<'_, '_>) -> fmt::Result {
+    fn visit_package(&self, package: PackageMetadata<'_>, f: &mut DotWrite<'_, '_>) -> fmt::Result {
         // Print out the name of the package. Other metadata can also be printed out.
         //
         // If you need to look at data for other packages, store a reference to the PackageGraph in

--- a/guppy/examples/remove_dev_only.rs
+++ b/guppy/examples/remove_dev_only.rs
@@ -13,7 +13,7 @@ use std::iter;
 fn main() -> Result<(), Error> {
     // `guppy` accepts `cargo metadata` JSON output. Use a pre-existing fixture for these examples.
     let fixture = include_str!("../fixtures/large/metadata_libra.json");
-    let mut package_graph = PackageGraph::from_json(fixture)?;
+    let package_graph = PackageGraph::from_json(fixture)?;
 
     // Pick an important binary package and compute the number of dependencies.
     //
@@ -59,30 +59,7 @@ fn main() -> Result<(), Error> {
         })
         .package_ids(DependencyDirection::Forward)
         .len();
-    println!("number of packages with resolve_with: {}", resolve_with_len);
-
-    // Alternatively, `retain_edges` takes a closure that returns `true` if this edge should be kept in the graph.
-    package_graph.retain_edges(|_data, link| {
-        // '_data' contains metadata for every package. It isn't used in this example but some
-        // complex filters may make use of it.
-        resolver_fn(link)
-    });
-
-    // Iterate over all links and assert that there are no dev-only links.
-    for link in package_graph
-        .resolve_all()
-        .links(DependencyDirection::Forward)
-    {
-        assert!(!link.dev_only());
-    }
-
-    // Count the number of packages after.
-    let after_count = package_graph
-        .query_forward(iter::once(&libra_node_id))?
-        .resolve()
-        .package_ids(DependencyDirection::Forward)
-        .count();
-    println!("number of packages after retain_edges: {}", after_count);
+    println!("number of packages after: {}", resolve_with_len);
 
     Ok(())
 }

--- a/guppy/src/graph/feature/build.rs
+++ b/guppy/src/graph/feature/build.rs
@@ -68,10 +68,8 @@ impl<'g> FeatureGraphBuildState<'g> {
     }
 
     pub(super) fn add_named_feature_edges(&mut self, metadata: PackageMetadata<'_>) {
-        let dep_name_to_metadata: HashMap<_, _> = self
-            .package_graph
-            .dep_links(metadata.id())
-            .expect("valid metadata")
+        let dep_name_to_metadata: HashMap<_, _> = metadata
+            .direct_links()
             .map(|link| (link.dep_name(), link.to()))
             .collect();
 

--- a/guppy/src/graph/feature/graph_impl.rs
+++ b/guppy/src/graph/feature/graph_impl.rs
@@ -312,18 +312,11 @@ impl<'g> FeatureId<'g> {
     }
 
     pub(super) fn node_to_feature(
-        metadata: &'g PackageMetadata,
+        metadata: PackageMetadata<'g>,
         node: &FeatureNode,
     ) -> Option<&'g str> {
         let feature_idx = node.feature_idx?;
-        Some(
-            metadata
-                .features
-                .get_index(feature_idx)
-                .expect("feature idx should be valid")
-                .0
-                .as_ref(),
-        )
+        metadata.feature_idx_to_name(feature_idx)
     }
 
     /// Returns the package ID.
@@ -476,17 +469,17 @@ impl FeatureNode {
         let metadata = feature_graph.package_graph.metadata(id.package_id())?;
         match id.feature() {
             Some(feature_name) => Some(FeatureNode::new(
-                metadata.package_ix,
+                metadata.package_ix(),
                 metadata.get_feature_idx(feature_name)?,
             )),
-            None => Some(FeatureNode::base(metadata.package_ix)),
+            None => Some(FeatureNode::base(metadata.package_ix())),
         }
     }
 
     pub(super) fn named_features<'g>(
-        package: &'g PackageMetadata,
+        package: PackageMetadata<'g>,
     ) -> impl Iterator<Item = Self> + 'g {
-        let package_ix = package.package_ix;
+        let package_ix = package.package_ix();
         package.named_features_full().map(move |(n, _, _)| Self {
             package_ix,
             feature_idx: Some(n),

--- a/guppy/src/graph/feature/resolve.rs
+++ b/guppy/src/graph/feature/resolve.rs
@@ -244,7 +244,7 @@ impl<'g> FeatureSet<'g> {
     pub fn packages_with_features<'a, B>(
         &'a self,
         direction: DependencyDirection,
-    ) -> impl Iterator<Item = (&'g PackageMetadata, B)> + 'a
+    ) -> impl Iterator<Item = (PackageMetadata<'g>, B)> + 'a
     where
         B: FromIterator<Option<&'g str>>,
     {
@@ -326,10 +326,10 @@ impl<'g> FeatureSet<'g> {
 
     fn features_for_package_impl<'a>(
         &'a self,
-        metadata: &'g PackageMetadata,
+        metadata: PackageMetadata<'g>,
     ) -> impl Iterator<Item = Option<&'g str>> + 'a {
         let dep_graph = self.graph.dep_graph();
-        let package_ix = metadata.package_ix;
+        let package_ix = metadata.package_ix();
         let core = &self.core;
 
         self.graph

--- a/guppy/src/graph/resolve.rs
+++ b/guppy/src/graph/resolve.rs
@@ -191,7 +191,7 @@ impl<'g> PackageSet<'g> {
     pub fn packages<'a>(
         &'a self,
         direction: DependencyDirection,
-    ) -> impl Iterator<Item = &'g PackageMetadata> + ExactSizeIterator + 'a {
+    ) -> impl Iterator<Item = PackageMetadata<'g>> + ExactSizeIterator + 'a {
         let graph = self.graph;
         self.package_ids(direction).map(move |package_id| {
             graph.metadata(package_id).unwrap_or_else(|| {
@@ -239,7 +239,7 @@ impl<'g> PackageSet<'g> {
     pub fn root_packages<'a>(
         &'a self,
         direction: DependencyDirection,
-    ) -> impl Iterator<Item = &'g PackageMetadata> + ExactSizeIterator + 'a {
+    ) -> impl Iterator<Item = PackageMetadata<'g>> + ExactSizeIterator + 'a {
         let package_graph = self.graph;
         self.core
             .roots(self.graph.dep_graph(), self.graph.sccs(), direction)
@@ -335,7 +335,7 @@ where
 pub trait PackageDotVisitor {
     /// Visits this package. The implementation may output a label for this package to the given
     /// `DotWrite`.
-    fn visit_package(&self, package: &PackageMetadata, f: &mut DotWrite<'_, '_>) -> fmt::Result;
+    fn visit_package(&self, package: PackageMetadata<'_>, f: &mut DotWrite<'_, '_>) -> fmt::Result;
 
     /// Visits this dependency link. The implementation may output a label for this link to the
     /// given `DotWrite`.

--- a/guppy/src/lib.rs
+++ b/guppy/src/lib.rs
@@ -31,9 +31,13 @@
 //! // `guppy` provides several ways to get hold of package IDs. Use a pre-defined one for this
 //! // example.
 //! let package_id = PackageId::new("testcrate 0.1.0 (path+file:///fakepath/testcrate)");
-//! // dep_links returns all direct dependencies of a package, and it returns `None` if the package
-//! // ID isn't recognized.
-//! for link in package_graph.dep_links(&package_id).unwrap() {
+//!
+//! // The `metadata` method returns information about the package, or `None` if the package ID
+//! // wasn't recognized.
+//! let package = package_graph.metadata(&package_id).unwrap();
+//!
+//! // `direct_links` returns all direct dependencies of a package.
+//! for link in package.direct_links() {
 //!     // A dependency link contains `from()`, `to()` and information about the specifics of the
 //!     // dependency.
 //!     println!("direct dependency: {}", link.to().id());

--- a/guppy/src/unit_tests/dep_helpers.rs
+++ b/guppy/src/unit_tests/dep_helpers.rs
@@ -99,8 +99,9 @@ pub(crate) fn assert_deps_internal(
         .map(|(dep_name, id)| (*dep_name, dep_name.replace("-", "_"), id))
         .collect();
     let actual_deps: Vec<_> = graph
-        .dep_links_directed(known_details.id(), direction)
-        .unwrap_or_else(|| panic!("{}: deps for package not found", msg))
+        .metadata(known_details.id())
+        .unwrap_or_else(|| panic!("{}: package not found", msg))
+        .direct_links_directed(direction)
         .into_iter()
         .collect();
     let mut actual_dep_ids: Vec<_> = actual_deps

--- a/guppy/src/unit_tests/fixtures.rs
+++ b/guppy/src/unit_tests/fixtures.rs
@@ -225,7 +225,7 @@ impl Fixture {
         for id in self.details.known_ids() {
             let msg = format!("error while verifying package '{}'", id);
             let metadata = self.graph.metadata(id).expect(&msg);
-            self.details.assert_metadata(id, &metadata, &msg);
+            self.details.assert_metadata(id, metadata, &msg);
 
             // Check for build targets.
             if self.details.has_build_targets(id) {
@@ -406,7 +406,7 @@ impl FixtureDetails {
         assert_all_links(graph, DependencyDirection::Reverse, "all links reversed");
     }
 
-    pub(crate) fn assert_metadata(&self, id: &PackageId, metadata: &PackageMetadata, msg: &str) {
+    pub(crate) fn assert_metadata(&self, id: &PackageId, metadata: PackageMetadata<'_>, msg: &str) {
         let details = &self.package_details[id];
         details.assert_metadata(metadata, msg);
     }
@@ -420,7 +420,7 @@ impl FixtureDetails {
         details.build_targets.is_some()
     }
 
-    pub(crate) fn assert_build_targets(&self, metadata: &PackageMetadata, msg: &str) {
+    pub(crate) fn assert_build_targets(&self, metadata: PackageMetadata<'_>, msg: &str) {
         let build_targets = self.package_details[metadata.id()]
             .build_targets
             .as_ref()
@@ -1602,7 +1602,7 @@ impl PackageDetails {
         }
     }
 
-    pub(crate) fn assert_metadata(&self, metadata: &PackageMetadata, msg: &str) {
+    pub(crate) fn assert_metadata(&self, metadata: PackageMetadata<'_>, msg: &str) {
         assert_eq!(&self.id, metadata.id(), "{}: same package ID", msg);
         assert_eq!(self.name, metadata.name(), "{}: same name", msg);
         assert_eq!(&self.version, metadata.version(), "{}: same version", msg);

--- a/guppy/src/unit_tests/fixtures.rs
+++ b/guppy/src/unit_tests/fixtures.rs
@@ -525,9 +525,11 @@ impl FixtureDetails {
 
     pub(crate) fn assert_link_details(&self, graph: &PackageGraph, msg: &str) {
         for ((from, to), details) in &self.link_details {
-            let mut links: Vec<_> = graph
-                .dep_links(from)
-                .unwrap_or_else(|| panic!("{}: known package ID '{}' should be valid", msg, from))
+            let metadata = graph
+                .metadata(from)
+                .unwrap_or_else(|| panic!("{}: known package ID '{}' should be valid", msg, from));
+            let mut links: Vec<_> = metadata
+                .direct_links()
                 .filter(|link| link.to().id() == to)
                 .collect();
             assert_eq!(

--- a/guppy/src/unit_tests/graph_tests.rs
+++ b/guppy/src/unit_tests/graph_tests.rs
@@ -24,10 +24,10 @@ mod small {
         metadata1.verify();
 
         let graph = metadata1.graph();
-        let mut root_deps: Vec<_> = graph
-            .dep_links(&fixtures::package_id(fixtures::METADATA1_TESTCRATE))
-            .expect("root crate deps should exist")
-            .collect();
+        let testcrate = graph
+            .metadata(&fixtures::package_id(fixtures::METADATA1_TESTCRATE))
+            .expect("root crate should exist");
+        let mut root_deps: Vec<_> = testcrate.direct_links().collect();
 
         assert_eq!(root_deps.len(), 1, "the root crate has one dependency");
         let link = root_deps.pop().expect("the root crate has one dependency");

--- a/guppy/src/unit_tests/graph_tests.rs
+++ b/guppy/src/unit_tests/graph_tests.rs
@@ -389,7 +389,7 @@ mod large {
 struct NameVisitor;
 
 impl PackageDotVisitor for NameVisitor {
-    fn visit_package(&self, package: &PackageMetadata, f: &mut DotWrite<'_, '_>) -> fmt::Result {
+    fn visit_package(&self, package: PackageMetadata<'_>, f: &mut DotWrite<'_, '_>) -> fmt::Result {
         write!(f, "{}", package.name())
     }
 


### PR DESCRIPTION
In practice this is how most people end up using these methods.