### PR TITLE
Make cargo_metadata a private dependency

### DIFF
--- a/guppy/src/dependency_kind.rs
+++ b/guppy/src/dependency_kind.rs
@@ -1,0 +1,43 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt;
+
+/// A descriptor for the kind of dependency.
+///
+/// Cargo dependencies may be one of three kinds.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum DependencyKind {
+    /// Normal dependencies.
+    ///
+    /// These are specified in the `[dependencies]` section.
+    Normal,
+
+    /// Dependencies used for development only.
+    ///
+    /// These are specified in the `[dev-dependencies]` section, and are used for tests,
+    /// benchmarks and similar.
+    Development,
+
+    /// Dependencies used for build scripts.
+    ///
+    /// These are specified in the `[build-dependencies]` section.
+    Build,
+}
+
+impl DependencyKind {
+    /// Returns a string representing the kind of dependency this is.
+    pub fn to_str(self) -> &'static str {
+        match self {
+            DependencyKind::Normal => "normal",
+            DependencyKind::Development => "dev",
+            DependencyKind::Build => "build",
+        }
+    }
+}
+
+impl fmt::Display for DependencyKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_str())
+    }
+}

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -7,8 +7,8 @@ use crate::graph::{
     PackageLinkImpl, PackageMetadataImpl, PlatformStatusImpl, WorkspaceImpl,
 };
 use crate::sorted_set::SortedSet;
-use crate::{Error, Metadata, PackageId};
-use cargo_metadata::{Dependency, DependencyKind, NodeDep, Package, Resolve, Target};
+use crate::{Error, PackageId};
+use cargo_metadata::{Dependency, DependencyKind, Metadata, NodeDep, Package, Resolve, Target};
 use once_cell::sync::OnceCell;
 use petgraph::prelude::*;
 use semver::Version;

--- a/guppy/src/graph/feature/graph_impl.rs
+++ b/guppy/src/graph/feature/graph_impl.rs
@@ -542,7 +542,6 @@ impl<'g> CrossLink<'g> {
             DependencyKind::Normal => self.normal(),
             DependencyKind::Build => self.build(),
             DependencyKind::Development => self.dev(),
-            _ => panic!("status requested for unknown kind: {:?}", kind),
         }
     }
 

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -7,8 +7,8 @@ use crate::graph::{
     DependencyDirection, OwnedBuildTargetId, PackageIx,
 };
 use crate::petgraph_support::scc::Sccs;
-use crate::{Error, JsonValue, Metadata, MetadataCommand, PackageId, Platform};
-use cargo_metadata::{DependencyKind, NodeDep};
+use crate::{DependencyKind, Error, JsonValue, Metadata, MetadataCommand, PackageId, Platform};
+use cargo_metadata::NodeDep;
 use fixedbitset::FixedBitSet;
 use indexmap::IndexMap;
 use once_cell::sync::OnceCell;
@@ -955,7 +955,6 @@ impl<'g> PackageLink<'g> {
             DependencyKind::Normal => self.normal(),
             DependencyKind::Development => self.dev(),
             DependencyKind::Build => self.build(),
-            _ => panic!("dependency metadata requested for unknown kind: {:?}", kind),
         }
     }
 

--- a/guppy/src/graph/mod.rs
+++ b/guppy/src/graph/mod.rs
@@ -7,7 +7,6 @@
 //! documentation for more details.
 
 use crate::PackageId;
-use cargo_metadata::DependencyKind;
 use petgraph::prelude::*;
 use std::fmt;
 
@@ -131,16 +130,6 @@ impl<'g> GraphSpec for feature::FeatureGraph<'g> {
     type Node = feature::FeatureNode;
     type Edge = feature::FeatureEdge;
     type Ix = FeatureIx;
-}
-
-#[allow(dead_code)]
-pub(crate) fn kind_str(kind: DependencyKind) -> &'static str {
-    match kind {
-        DependencyKind::Normal => "normal",
-        DependencyKind::Build => "build",
-        DependencyKind::Development => "dev",
-        _ => "unknown",
-    }
 }
 
 // A requirement of "*" filters out pre-release versions with the semver crate,

--- a/guppy/src/lib.rs
+++ b/guppy/src/lib.rs
@@ -50,6 +50,7 @@
 #![warn(missing_docs)]
 
 mod debug_ignore;
+mod dependency_kind;
 pub mod errors;
 pub mod graph;
 mod metadata_command;
@@ -59,14 +60,13 @@ pub(crate) mod sorted_set;
 #[cfg(test)]
 mod unit_tests;
 
+pub use dependency_kind::*;
 pub use errors::Error;
 pub use metadata_command::*;
 pub use package_id::PackageId;
 
 // Public re-exports for upstream crates used in APIs. The no_inline ensures that they show up as
 // re-exports in documentation.
-#[doc(no_inline)]
-pub use cargo_metadata::DependencyKind;
 #[doc(no_inline)]
 pub use semver::Version;
 #[doc(no_inline)]

--- a/guppy/src/lib.rs
+++ b/guppy/src/lib.rs
@@ -52,6 +52,7 @@
 mod debug_ignore;
 pub mod errors;
 pub mod graph;
+mod metadata_command;
 mod package_id;
 pub(crate) mod petgraph_support;
 pub(crate) mod sorted_set;
@@ -59,12 +60,13 @@ pub(crate) mod sorted_set;
 mod unit_tests;
 
 pub use errors::Error;
+pub use metadata_command::*;
 pub use package_id::PackageId;
 
 // Public re-exports for upstream crates used in APIs. The no_inline ensures that they show up as
 // re-exports in documentation.
 #[doc(no_inline)]
-pub use cargo_metadata::{DependencyKind, Metadata, MetadataCommand};
+pub use cargo_metadata::DependencyKind;
 #[doc(no_inline)]
 pub use semver::Version;
 #[doc(no_inline)]

--- a/guppy/src/metadata_command.rs
+++ b/guppy/src/metadata_command.rs
@@ -79,7 +79,7 @@ impl MetadataCommand {
 
     /// Runs the configured `cargo metadata` and returns a parsed `Metadata`.
     pub fn exec(&mut self) -> Result<Metadata, Error> {
-        let inner = self.inner.exec().map_err(Error::CommandError)?;
+        let inner = self.inner.exec().map_err(Error::command_error)?;
         Ok(Metadata(inner))
     }
 

--- a/guppy/src/metadata_command.rs
+++ b/guppy/src/metadata_command.rs
@@ -1,0 +1,113 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::graph::PackageGraph;
+use crate::Error;
+use cargo_metadata::CargoOpt;
+use std::path::Path;
+
+/// A builder for configuring `cargo metadata` invocations.
+///
+/// ## Examples
+///
+/// Build a `PackageGraph` for the Cargo workspace in the current directory:
+///
+/// ```rust
+/// use guppy::MetadataCommand;
+/// use guppy::graph::PackageGraph;
+///
+/// let mut cmd = MetadataCommand::new();
+/// let package_graph = PackageGraph::from_command(&mut cmd);
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct MetadataCommand {
+    inner: cargo_metadata::MetadataCommand,
+}
+
+impl MetadataCommand {
+    /// Creates a default `cargo metadata` command builder.
+    ///
+    /// By default, this will look for `Cargo.toml` in the ancestors of this process's current
+    /// directory.
+    pub fn new() -> Self {
+        let mut inner = cargo_metadata::MetadataCommand::new();
+        // Always use --all-features so that we get a full view of the graph.
+        inner.features(CargoOpt::AllFeatures);
+        Self { inner }
+    }
+
+    /// Sets the path to the `cargo` executable.
+    ///
+    /// If unset, this will use the `$CARGO` environment variable, or else `cargo` from `$PATH`.
+    pub fn cargo_path(&mut self, path: impl AsRef<Path>) -> &mut Self {
+        self.inner.cargo_path(path);
+        self
+    }
+
+    /// Sets the path to `Cargo.toml`.
+    ///
+    /// By default, this will look for `Cargo.toml` in the ancestors of the current directory. Note
+    /// that this doesn't need to be the root `Cargo.toml` in a workspace -- any member of the
+    /// workspace is fine.
+    pub fn manifest_path(&mut self, path: impl AsRef<Path>) -> &mut Self {
+        self.inner.manifest_path(path);
+        self
+    }
+
+    /// Sets the current directory of the `cargo metadata` process.
+    ///
+    /// By default, the current directory will be inherited from this process.
+    pub fn current_dir(&mut self, path: impl AsRef<Path>) -> &mut Self {
+        self.inner.current_dir(path);
+        self
+    }
+
+    // *Do not* implement no_deps or features.
+
+    /// Arbitrary flags to pass to `cargo metadata`. These will be added to the end of the
+    /// command invocation.
+    ///
+    /// Note that `guppy` internally:
+    /// * passes in `--all-features`, so that `guppy` has a full view of the dependency graph.
+    /// * does not pass in `--no-deps`, so that `guppy` knows about non-workspace dependencies.
+    ///
+    /// Attempting to override either of those options may lead to unexpected results.
+    pub fn other_options(&mut self, options: impl AsRef<[String]>) -> &mut Self {
+        self.inner.other_options(options);
+        self
+    }
+
+    /// Runs the configured `cargo metadata` and returns a parsed `Metadata`.
+    pub fn exec(&mut self) -> Result<Metadata, Error> {
+        let inner = self.inner.exec().map_err(Error::CommandError)?;
+        Ok(Metadata(inner))
+    }
+
+    /// Runs the configured `cargo metadata` and returns a parsed `PackageGraph`.
+    pub fn build_graph(&mut self) -> Result<PackageGraph, Error> {
+        let metadata = self.exec()?;
+        metadata.into_package_graph()
+    }
+}
+
+/// A parsed `Cargo` metadata returned by a `MetadataCommand`.
+///
+/// This is an intermediate, opaque struct which may be generated either through
+/// `MetadataCommand::to_metadata` or through deserializing JSON representing `cargo metadata`. To
+/// analyze Cargo metadata by building a `PackageGraph`
+/// from it, call the `into_package_graph` method.
+#[derive(Clone, Debug)]
+pub struct Metadata(pub(crate) cargo_metadata::Metadata);
+
+impl Metadata {
+    /// Parses this JSON blob into a `Metadata`.
+    pub fn parse_json(json: impl AsRef<str>) -> Result<Self, Error> {
+        let inner = serde_json::from_str(json.as_ref()).map_err(Error::MetadataParseError)?;
+        Ok(Self(inner))
+    }
+
+    /// Builds a `PackageGraph` out of this `Metadata`.
+    pub fn into_package_graph(self) -> Result<PackageGraph, Error> {
+        PackageGraph::from_metadata(self)
+    }
+}

--- a/guppy/src/unit_tests/dep_helpers.rs
+++ b/guppy/src/unit_tests/dep_helpers.rs
@@ -3,7 +3,7 @@
 
 use crate::graph::feature::{FeatureGraph, FeatureId, FeatureMetadata, FeatureQuery, FeatureSet};
 use crate::graph::{
-    kind_str, DependencyDirection, DependencyReq, PackageGraph, PackageLink, PackageLinkImpl,
+    DependencyDirection, DependencyReq, PackageGraph, PackageLink, PackageLinkImpl,
     PackageMetadata, PackageMetadataImpl, PackageQuery, PackageSet,
 };
 use crate::unit_tests::fixtures::PackageDetails;
@@ -330,7 +330,7 @@ pub(crate) fn assert_all_links(graph: &PackageGraph, direction: DependencyDirect
                     msg,
                     link.from().id(),
                     link.to().id(),
-                    kind_str(*dep_kind)
+                    dep_kind,
                 ),
             );
         }

--- a/guppy/src/unit_tests/fixtures.rs
+++ b/guppy/src/unit_tests/fixtures.rs
@@ -3,7 +3,7 @@
 
 use crate::errors::FeatureBuildStage;
 use crate::graph::{
-    kind_str, BuildTargetId, BuildTargetKind, DependencyDirection, EnabledStatus, EnabledTernary,
+    BuildTargetId, BuildTargetKind, DependencyDirection, EnabledStatus, EnabledTernary,
     PackageGraph, PackageLink, PackageMetadata, Workspace,
 };
 use crate::unit_tests::dep_helpers::{
@@ -1683,7 +1683,7 @@ impl LinkDetails {
                 "{}: for platform '{}', kind {}, status is correct",
                 msg,
                 platform.triple(),
-                kind_str(*dep_kind),
+                dep_kind,
             );
             assert_eq!(
                 required_enabled(req.default_features(), platform),
@@ -1691,7 +1691,7 @@ impl LinkDetails {
                 "{}: for platform '{}', kind {}, default features is correct",
                 msg,
                 platform.triple(),
-                kind_str(*dep_kind),
+                dep_kind,
             );
             for (feature, status) in &results.feature_statuses {
                 assert_eq!(
@@ -1700,7 +1700,7 @@ impl LinkDetails {
                     "{}: for platform '{}', kind {}, feature '{}' has correct status",
                     msg,
                     platform.triple(),
-                    kind_str(*dep_kind),
+                    dep_kind,
                     feature
                 );
             }

--- a/guppy/src/unit_tests/fixtures.rs
+++ b/guppy/src/unit_tests/fixtures.rs
@@ -10,7 +10,7 @@ use crate::unit_tests::dep_helpers::{
     assert_all_links, assert_deps_internal, assert_topo_ids, assert_topo_metadatas,
     assert_transitive_deps_internal,
 };
-use crate::{errors::FeatureGraphWarning, DependencyKind, PackageId, Platform};
+use crate::{errors::FeatureGraphWarning, DependencyKind, Metadata, PackageId, Platform};
 use once_cell::sync::Lazy;
 use pretty_assertions::assert_eq;
 use semver::Version;
@@ -289,8 +289,8 @@ impl Fixture {
     define_fixture!(metadata_libra_9ffd93b, METADATA_LIBRA_9FFD93B);
 
     fn parse_graph(json: &str) -> PackageGraph {
-        let metadata = serde_json::from_str(json).expect("parsing metadata JSON should succeed");
-        PackageGraph::new(metadata).expect("constructing package graph should succeed")
+        let metadata = Metadata::parse_json(json).expect("parsing metadata JSON should succeed");
+        PackageGraph::from_metadata(metadata).expect("constructing package graph should succeed")
     }
 }
 


### PR DESCRIPTION
This allows us to impose some constraints on what is required, and upgrade `cargo_metadata` without breaking semver compat.