### PR TITLE
[cargo-guppy] Bring resolve-cargo to mostly feature parity with select

### DIFF
--- a/guppy/src/graph/feature/query.rs
+++ b/guppy/src/graph/feature/query.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::graph::cargo::{CargoOptions, CargoSet};
+use crate::graph::cargo::{CargoOptions, CargoPostfilter, CargoSet};
 use crate::graph::feature::{CrossLink, FeatureGraph, FeatureId, FeatureSet};
 use crate::graph::query_core::QueryParams;
 use crate::graph::{DependencyDirection, FeatureIx, PackageQuery};
@@ -301,7 +301,10 @@ impl<'g> FeatureQuery<'g> {
     /// features.
     ///
     /// There is some flexibility in how packages are built in the end.
-    pub fn resolve_cargo(self, opts: &CargoOptions<'_>) -> Result<CargoSet<'g>, Error> {
+    pub fn resolve_cargo<PF>(self, opts: &mut CargoOptions<'_, PF>) -> Result<CargoSet<'g>, Error>
+    where
+        PF: CargoPostfilter<'g>,
+    {
         CargoSet::new(self, opts)
     }
 }

--- a/tools/cargo-compare/src/common.rs
+++ b/tools/cargo-compare/src/common.rs
@@ -158,12 +158,12 @@ impl GuppyCargoCommon {
             _ => panic!("unknown resolver version {:?}", version),
         };
 
-        let cargo_opts = CargoOptions::new()
+        let mut cargo_opts = CargoOptions::new()
             .with_version(version)
             .with_dev_deps(self.include_dev)
             .with_target_platform(target_platform.as_ref())
             .with_host_platform(host_platform.as_ref());
-        let cargo_set = feature_query.resolve_cargo(&cargo_opts)?;
+        let cargo_set = feature_query.resolve_cargo(&mut cargo_opts)?;
 
         Ok(FeatureMap::from_guppy(&cargo_set, merge_maps))
     }


### PR DESCRIPTION
Add `--omit-edges-into`, `--build-kind` for host/target and `--kind`.

This ended up being a breaking change because of `&mut` in `CargoOptions` -- ah well. We'll live, and it's probably more useful to have the `&mut` than not.