### PR TITLE
[guppy] Don't use serde::export private types

### DIFF
--- a/guppy/src/graph/resolve_core.rs
+++ b/guppy/src/graph/resolve_core.rs
@@ -18,7 +18,7 @@ use petgraph::{
     prelude::*,
     visit::{NodeFiltered, Reversed, VisitMap},
 };
-use serde::export::PhantomData;
+use std::marker::PhantomData;
 
 /// Core logic for queries that have been resolved into a known set of packages.
 ///


### PR DESCRIPTION
Serde had a `serde::export` module exposed for use in its proc-macro derive crates, though it was never intended to be used publicly.

With the latest serde release (1.0.119) the `serde::export` module was finally renamed to `serde::__private` to more clearly express that downstream crates should not depend on it: (https://github.com/serde-rs/serde/blob/master/serde/src/lib.rs#L275).