### PR TITLE
[guppy] return packages in cycles in non-dev order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "guppy"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cargo_metadata",
  "fixedbitset",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "target-spec"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cfg-expr",
  "proptest",

--- a/cargo-guppy/Cargo.toml
+++ b/cargo-guppy/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 anyhow = "1.0.38"
 clap = "2.33.3"
 dialoguer = "0.7.1"
-guppy = { version = "0.7.0", path = "../guppy", features = ["summaries"] }
+guppy = { version = "0.7.1", path = "../guppy", features = ["summaries"] }
 guppy-cmdlib = { path = "../guppy-cmdlib" }
 itertools = "0.10.0"
 pathdiff = "0.2.0"

--- a/fixtures/src/dep_helpers.rs
+++ b/fixtures/src/dep_helpers.rs
@@ -520,6 +520,7 @@ pub trait GraphAssert<'g>: Copy + fmt::Debug {
     ) {
         if self.is_cyclic(a_id, b_id).unwrap() {
             // This is a dependency cycle -- ignore it in not-depends-on checks.
+            // TODO: make this smarter now that cycles are handled in non-dev order.
             return;
         }
 

--- a/fixtures/src/details.rs
+++ b/fixtures/src/details.rs
@@ -71,15 +71,12 @@ impl FixtureDetails {
     }
 
     pub fn with_cycles(mut self, cycles: Vec<Vec<&'static str>>) -> Self {
-        let mut cycles: Vec<_> = cycles
+        let cycles: Vec<_> = cycles
             .into_iter()
-            .map(|cycle| {
-                let mut cycle: Vec<_> = cycle.into_iter().map(package_id).collect();
-                cycle.sort();
-                cycle
-            })
+            .map(|cycle| cycle.into_iter().map(package_id).collect())
             .collect();
-        cycles.sort();
+        // Don't sort because the order returned by all_cycles (both the outer and inner vecs) is
+        // significant.
         self.cycles = cycles;
         self
     }
@@ -292,17 +289,9 @@ impl FixtureDetails {
     // ---
 
     pub fn assert_cycles(&self, graph: &PackageGraph, msg: &str) {
-        let mut actual: Vec<_> = graph
-            .cycles()
-            .all_cycles()
-            .map(|cycle| {
-                let mut cycle: Vec<_> = cycle.into_iter().collect();
-                cycle.sort();
-                cycle
-            })
-            .collect();
-        actual.sort();
-
+        let actual: Vec<_> = graph.cycles().all_cycles().collect();
+        // Don't sort because the order returned by all_cycles (both the outer and inner vecs) is
+        // significant.
         assert_eq!(&self.cycles, &actual, "{}", msg);
     }
 }

--- a/fixtures/src/json.rs
+++ b/fixtures/src/json.rs
@@ -607,7 +607,7 @@ impl FixtureDetails {
 
         Self::new(details)
             .with_workspace_members(vec![("", METADATA_CYCLE1_BASE)])
-            .with_cycles(vec![vec![METADATA_CYCLE1_BASE, METADATA_CYCLE1_HELPER]])
+            .with_cycles(vec![vec![METADATA_CYCLE1_HELPER, METADATA_CYCLE1_BASE]])
     }
 
     pub(crate) fn metadata_cycle2() -> Self {
@@ -715,7 +715,9 @@ impl FixtureDetails {
                 ("lower-b", METADATA_CYCLE2_LOWER_B),
             ])
             .with_cycles(vec![
+                // upper-b dev-depends on upper-a, and upper-a normal-depends on upper-b.
                 vec![METADATA_CYCLE2_UPPER_A, METADATA_CYCLE2_UPPER_B],
+                // lower-b dev-depends on lower-a, and lower-a normal-depends on lower-b.
                 vec![METADATA_CYCLE2_LOWER_A, METADATA_CYCLE2_LOWER_B],
             ])
     }
@@ -729,8 +731,8 @@ impl FixtureDetails {
                 ("testcycles-helper", METADATA_CYCLE_FEATURES_HELPER),
             ])
             .with_cycles(vec![vec![
-                METADATA_CYCLE_FEATURES_BASE,
                 METADATA_CYCLE_FEATURES_HELPER,
+                METADATA_CYCLE_FEATURES_BASE,
             ]])
     }
 
@@ -1254,9 +1256,9 @@ impl FixtureDetails {
         Self::new(details).with_cycles(vec![vec![
             METADATA_LIBRA_FUNCTIONAL_HYPHEN_TESTS,
             METADATA_LIBRA_E2E_TESTS,
-            METADATA_LIBRA_MOVE_LANG,
-            METADATA_LIBRA_MOVE_LANG_STDLIB,
             METADATA_LIBRA_VM_GENESIS,
+            METADATA_LIBRA_MOVE_LANG_STDLIB,
+            METADATA_LIBRA_MOVE_LANG,
         ]])
     }
 
@@ -1264,18 +1266,18 @@ impl FixtureDetails {
         let details = HashMap::new();
 
         Self::new(details).with_cycles(vec![
+            vec![METADATA_LIBRA_EXECUTOR_UTILS, METADATA_LIBRA_EXECUTOR],
             vec![
-                METADATA_LIBRA_COMPILER,
                 METADATA_LIBRA_FUNCTIONAL_HYPHEN_TESTS,
                 METADATA_LIBRA_E2E_TESTS,
-                METADATA_LIBRA_LIBRA_VM,
-                METADATA_LIBRA_MOVE_LANG,
-                METADATA_LIBRA_MOVE_VM_RUNTIME,
-                METADATA_LIBRA_STDLIB,
-                METADATA_LIBRA_TRANSACTION_BUILDER,
+                METADATA_LIBRA_COMPILER,
                 METADATA_LIBRA_VM_GENESIS,
+                METADATA_LIBRA_LIBRA_VM,
+                METADATA_LIBRA_MOVE_VM_RUNTIME,
+                METADATA_LIBRA_TRANSACTION_BUILDER,
+                METADATA_LIBRA_STDLIB,
+                METADATA_LIBRA_MOVE_LANG,
             ],
-            vec![METADATA_LIBRA_EXECUTOR, METADATA_LIBRA_EXECUTOR_UTILS],
         ])
     }
 

--- a/guppy/CHANGELOG.md
+++ b/guppy/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.7.1] - 2020-02-14
+
+### Changed
+
+- Packages within a cycle are now returned in non-dev order. When the direction is forward,
+  if package Foo has a dependency on Bar, and Bar has a cyclic dev-dependency on
+  Foo, then Foo is returned before Bar. (This is not a breaking change because it is an additional
+  constraint on guppy itself, not on its consumers.)
+
 ## [0.7.0] - 2020-02-03
 
 ### Added
@@ -314,6 +323,7 @@ lazy_static = "0.2"
 ### Added
 - Initial release.
 
+[0.7.1]: https://github.com/facebookincubator/cargo-guppy/releases/tag/guppy-0.7.1
 [0.7.0]: https://github.com/facebookincubator/cargo-guppy/releases/tag/guppy-0.7.0
 [0.6.3]: https://github.com/facebookincubator/cargo-guppy/releases/tag/guppy-0.6.3
 [0.6.2]: https://github.com/facebookincubator/cargo-guppy/releases/tag/guppy-0.6.2

--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "guppy"
-version = "0.7.0"
+version = "0.7.1"
 description = "Track and query Cargo dependency graphs."
 documentation = "https://docs.rs/guppy"
 repository = "https://github.com/facebookincubator/cargo-guppy"
@@ -48,7 +48,7 @@ semver = "0.11.0"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
 supercow = "0.1.0"
-target-spec = { version = "0.6.0", path = "../target-spec" }
+target-spec = { version = "0.6.1", path = "../target-spec" }
 
 [dev-dependencies]
 fixtures = { path = "../fixtures" }

--- a/guppy/src/graph/cycles.rs
+++ b/guppy/src/graph/cycles.rs
@@ -37,8 +37,14 @@ impl<'g> Cycles<'g> {
 
     /// Returns all the cycles of 2 or more elements in this graph.
     ///
-    /// The order returned within each cycle is arbitrary.
-    pub fn all_cycles(&self) -> impl Iterator<Item = Vec<&'g PackageId>> + 'g {
+    /// Cycles are returned in topological order: if packages in cycle B depend on packages in cycle
+    /// A, A is returned before B.
+    ///
+    /// Within a cycle, nodes are returned in non-dev order: if package Foo has a dependency on Bar,
+    /// and Bar has a cyclic dev-dependency on Foo, then Foo is returned before Bar.
+    pub fn all_cycles(
+        &self,
+    ) -> impl Iterator<Item = Vec<&'g PackageId>> + DoubleEndedIterator + 'g {
         let dep_graph = &self.package_graph.dep_graph;
         self.sccs
             .multi_sccs()

--- a/guppy/src/graph/feature/cycles.rs
+++ b/guppy/src/graph/feature/cycles.rs
@@ -46,7 +46,11 @@ impl<'g> Cycles<'g> {
 
     /// Returns all the cycles of 2 or more elements in this graph.
     ///
-    /// The order returned within each cycle is arbitrary.
+    /// Cycles are returned in topological order: if features in cycle B depend on features in cycle
+    /// A, A is returned before B.
+    ///
+    /// Within a cycle, nodes are returned in non-dev order: if feature Foo has a dependency on Bar,
+    /// and Bar has a dev-dependency on Foo, then Foo is returned before Bar.
     pub fn all_cycles(&self) -> impl Iterator<Item = Vec<FeatureId<'g>>> + 'g {
         let dep_graph = self.feature_graph.dep_graph();
         let package_graph = self.feature_graph.package_graph;

--- a/guppy/src/graph/feature/resolve.rs
+++ b/guppy/src/graph/feature/resolve.rs
@@ -282,8 +282,9 @@ impl<'g> FeatureSet<'g> {
     ///
     /// ## Cycles
     ///
-    /// The packages within a dependency cycle will be returned in arbitrary order, but overall
-    /// topological order will be maintained.
+    /// The features within a dependency cycle will be returned in non-dev order. When the direction
+    /// is forward, if feature Foo has a dependency on Bar, and Bar has a cyclic dev-dependency on
+    /// Foo, then Foo is returned before Bar.
     pub fn feature_ids<'a>(
         &'a self,
         direction: DependencyDirection,
@@ -300,8 +301,9 @@ impl<'g> FeatureSet<'g> {
     ///
     /// ## Cycles
     ///
-    /// The packages within a dependency cycle will be returned in arbitrary order, but overall
-    /// topological order will be maintained.
+    /// The features within a dependency cycle will be returned in non-dev order. When the direction
+    /// is forward, if feature Foo has a dependency on Bar, and Bar has a cyclic dev-dependency on
+    /// Foo, then Foo is returned before Bar.
     pub fn features<'a>(
         &'a self,
         direction: DependencyDirection,
@@ -321,8 +323,9 @@ impl<'g> FeatureSet<'g> {
     ///
     /// ## Cycles
     ///
-    /// The packages within a dependency cycle will be returned in arbitrary order, but overall
-    /// topological order will be maintained.
+    /// The packages within a dependency cycle will be returned in non-dev order. When the direction
+    /// is forward, if package Foo has a dependency on Bar, and Bar has a cyclic dev-dependency on
+    /// Foo, then Foo is returned before Bar.
     pub fn packages_with_features<'a>(
         &'a self,
         direction: DependencyDirection,
@@ -352,7 +355,7 @@ impl<'g> FeatureSet<'g> {
     /// ## Cycles
     ///
     /// If a root consists of a dependency cycle, all the packages in it will be returned in
-    /// arbitrary order.
+    /// non-dev order (when the direction is forward).
     pub fn root_ids<'a>(
         &'a self,
         direction: DependencyDirection,
@@ -375,7 +378,7 @@ impl<'g> FeatureSet<'g> {
     /// ## Cycles
     ///
     /// If a root consists of a dependency cycle, all the packages in it will be returned in
-    /// arbitrary order.}
+    /// non-dev order (when the direction is forward).
     pub fn root_features<'a>(
         &'a self,
         direction: DependencyDirection,
@@ -395,7 +398,9 @@ impl<'g> FeatureSet<'g> {
     ///
     /// ## Cycles
     ///
-    /// The links in a dependency cycle may be returned in arbitrary order.
+    /// The links in a dependency cycle will be returned in non-dev order. When the direction is
+    /// forward, if feature Foo has a dependency on Bar, and Bar has a cyclic dev-dependency on Foo,
+    /// then the link Foo -> Bar is returned before the link Bar -> Foo.
     pub fn cross_links<'a>(
         &'a self,
         direction: DependencyDirection,

--- a/guppy/src/graph/resolve.rs
+++ b/guppy/src/graph/resolve.rs
@@ -315,8 +315,9 @@ impl<'g> PackageSet<'g> {
     ///
     /// ## Cycles
     ///
-    /// The packages within a dependency cycle will be returned in arbitrary order, but overall
-    /// topological order will be maintained.
+    /// The packages within a dependency cycle will be returned in non-dev order. When the direction
+    /// is forward, if package Foo has a dependency on Bar, and Bar has a cyclic dev-dependency on
+    /// Foo, then Foo is returned before Bar.
     pub fn package_ids<'a>(
         &'a self,
         direction: DependencyDirection,
@@ -335,8 +336,9 @@ impl<'g> PackageSet<'g> {
     ///
     /// ## Cycles
     ///
-    /// The packages within a dependency cycle will be returned in arbitrary order, but overall
-    /// topological order will be maintained.
+    /// The packages within a dependency cycle will be returned in non-dev order. When the direction
+    /// is forward, if package Foo has a dependency on Bar, and Bar has a cyclic dev-dependency on
+    /// Foo, then Foo is returned before Bar.
     pub fn packages<'a>(
         &'a self,
         direction: DependencyDirection,
@@ -356,7 +358,7 @@ impl<'g> PackageSet<'g> {
     /// ## Cycles
     ///
     /// If a root consists of a dependency cycle, all the packages in it will be returned in
-    /// arbitrary order.
+    /// non-dev order (when the direction is forward).
     pub fn root_ids<'a>(
         &'a self,
         direction: DependencyDirection,
@@ -378,7 +380,7 @@ impl<'g> PackageSet<'g> {
     /// ## Cycles
     ///
     /// If a root consists of a dependency cycle, all the packages in it will be returned in
-    /// arbitrary order.
+    /// non-dev order (when the direction is forward).
     pub fn root_packages<'a>(
         &'a self,
         direction: DependencyDirection,
@@ -406,7 +408,9 @@ impl<'g> PackageSet<'g> {
     ///
     /// ## Cycles
     ///
-    /// The links in a dependency cycle may be returned in arbitrary order.
+    /// The links in a dependency cycle will be returned in non-dev order. When the direction is
+    /// forward, if package Foo has a dependency on Bar, and Bar has a cyclic dev-dependency on Foo,
+    /// then the link Foo -> Bar is returned before the link Bar -> Foo.
     pub fn links<'a>(
         &'a self,
         direction: DependencyDirection,

--- a/guppy/src/petgraph_support/mod.rs
+++ b/guppy/src/petgraph_support/mod.rs
@@ -14,6 +14,7 @@ pub mod dfs;
 pub mod dot;
 pub mod edge_ref;
 pub mod scc;
+pub mod topo;
 pub mod walk;
 
 pub fn edge_triple<ER: EdgeRef>(edge_ref: ER) -> (ER::NodeId, ER::NodeId, ER::EdgeId) {

--- a/guppy/src/petgraph_support/topo.rs
+++ b/guppy/src/petgraph_support/topo.rs
@@ -1,0 +1,64 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use petgraph::{
+    graph::IndexType,
+    prelude::*,
+    visit::{
+        GraphRef, IntoNeighborsDirected, IntoNodeIdentifiers, NodeCompactIndexable, Visitable,
+        Walker,
+    },
+};
+
+/// A cycle-aware topological sort of a graph.
+#[derive(Clone, Debug)]
+pub struct TopoWithCycles<Ix> {
+    topo: Box<[NodeIndex<Ix>]>,
+    reverse_index: Box<[usize]>,
+}
+
+impl<Ix: IndexType> TopoWithCycles<Ix> {
+    pub fn new<G>(graph: G) -> Self
+    where
+        G: GraphRef
+            + Visitable<NodeId = NodeIndex<Ix>>
+            + IntoNodeIdentifiers
+            + IntoNeighborsDirected<NodeId = NodeIndex<Ix>>
+            + NodeCompactIndexable,
+    {
+        // petgraph's default topo algorithms don't handle cycles. Use DfsPostOrder which does.
+        let mut dfs = DfsPostOrder::empty(graph);
+        dfs.stack.extend(
+            graph
+                .node_identifiers()
+                .filter(move |&a| graph.neighbors_directed(a, Incoming).next().is_none()),
+        );
+        let mut topo: Vec<NodeIndex<Ix>> = dfs.iter(graph).collect();
+        // dfs returns its data in postorder (reverse topo order), so reverse that for forward topo
+        // order.
+        topo.reverse();
+
+        // Because the graph is NodeCompactIndexable, the indexes are in the range (0..topo.len()).
+        // Use this property to build a reverse map.
+        let mut reverse_index = vec![0; topo.len()];
+        topo.iter().enumerate().for_each(|(topo_ix, node_ix)| {
+            reverse_index[node_ix.index()] = topo_ix;
+        });
+
+        Self {
+            topo: topo.into_boxed_slice(),
+            reverse_index: reverse_index.into_boxed_slice(),
+        }
+    }
+
+    /// Sort nodes based on the topo order in self.
+    #[inline]
+    pub fn sort_nodes(&self, nodes: &mut Vec<NodeIndex<Ix>>) {
+        nodes.sort_unstable_by_key(|node_ix| self.topo_ix(*node_ix))
+    }
+
+    #[inline]
+    pub fn topo_ix(&self, node_ix: NodeIndex<Ix>) -> usize {
+        self.reverse_index[node_ix.index()]
+    }
+}

--- a/internal-tools/benchmarks/benches/package_graph.rs
+++ b/internal-tools/benchmarks/benches/package_graph.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use guppy::{
     graph::{DependencyDirection, PackageGraph, PackageMetadata},
     PackageId,
@@ -80,6 +80,13 @@ pub fn query_benchmarks(c: &mut Criterion) {
                 Some(2),
                 "2 versions of syn"
             );
+        })
+    });
+
+    c.bench_function("make_cycles", |b| {
+        b.iter(|| {
+            package_graph.invalidate_caches();
+            black_box(package_graph.cycles());
         })
     });
 }

--- a/target-spec/CHANGELOG.md
+++ b/target-spec/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.1] - 2020-02-14
+
+### Changed
+
+- `cfg-expr` version requirement relaxed: 0.6 through 0.7 are now supported. There are no API changes between
+  the two versions.
+
 ## [0.6.0] - 2020-02-03
 
 ### Added
@@ -85,6 +92,7 @@ This was mistakenly published and was yanked.
 ## [0.1.0] - 2020-03-20
 - Initial release.
 
+[0.6.1]: https://github.com/facebookincubator/cargo-guppy/releases/tag/target-spec-0.6.1
 [0.6.0]: https://github.com/facebookincubator/cargo-guppy/releases/tag/target-spec-0.6.0
 [0.5.0]: https://github.com/facebookincubator/cargo-guppy/releases/tag/target-spec-0.5.0
 [0.4.1]: https://github.com/facebookincubator/cargo-guppy/releases/tag/target-spec-0.4.1

--- a/target-spec/Cargo.toml
+++ b/target-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "target-spec"
-version = "0.6.0"
+version = "0.6.1"
 description = "Evaluate Cargo.toml target specifications"
 documentation = "https://docs.rs/target-spec"
 repository = "https://github.com/facebookincubator/cargo-guppy"

--- a/tools/determinator/Cargo.toml
+++ b/tools/determinator/Cargo.toml
@@ -29,7 +29,7 @@ include = [
 [dependencies]
 cfg-if = "1.0.0"
 globset = "0.4.6"
-guppy = { version = "0.7.0", path = "../../guppy", features = ["rayon1", "summaries"] }
+guppy = { version = "0.7.1", path = "../../guppy", features = ["rayon1", "summaries"] }
 itertools = "0.10"
 once_cell = "1.5.2"
 petgraph = { version = "0.5", default-features = false, features = ["graphmap"] }

--- a/tools/hakari/Cargo.toml
+++ b/tools/hakari/Cargo.toml
@@ -26,7 +26,7 @@ all-features = true
 atomicwrites = "0.2.5"
 cfg-if = "1.0.0"
 diffy = "0.2.1"
-guppy = { version = "0.7.0", path = "../../guppy", features = ["rayon1"] }
+guppy = { version = "0.7.1", path = "../../guppy", features = ["rayon1"] }
 pathdiff = "0.2.0"
 proptest = { version = "0.10", optional = true }
 proptest-derive = { version = "0.2.0", optional = true }


### PR DESCRIPTION
Before this PR, packages in cycles could be returned in arbitrary
order. But there is a natural order to return them in: non-dev order.

This is not a breaking change because it's just an additional API constraint
on guppy that didn't exist before.

Constructing cycles does become slower as a result, but it's still
pretty fast. There's likely more scope for optimization in the future.

```
make_cycles             time:   [118.21 us 119.18 us 120.11 us]
                        change: [+77.496% +78.481% +79.512%] (p = 0.00 < 0.05)
```