### PR TITLE
cargo: fix cargo subcommand argument passing on Windows

### DIFF
--- a/cargo-guppy/src/main.rs
+++ b/cargo-guppy/src/main.rs
@@ -49,12 +49,26 @@ enum Command {
     Mv(MvOptions),
 }
 
+// On Unix-like operating systems, the executable name of the Cargo subcommand usually doesn't have
+// a file extension, while on Windows, executables usually have a ".exe" extension.
+fn executable_name(subcommand: &str) -> String {
+    #[cfg(target_os = "windows")]
+    {
+        format!("cargo-{}.exe", subcommand)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        format!("cargo-{}", subcommand)
+    }
+}
+
 // When invoked as a cargo subcommand, cargo passes too many arguments so we need to filter out
 // arg[1] if it matches the end of arg[0], e.i. "cargo-X X foo" should become "cargo-X foo".
 fn args() -> impl Iterator<Item = String> {
     let mut args: Vec<String> = ::std::env::args().collect();
 
-    if args.len() >= 2 && args[0].ends_with(&format!("cargo-{}", args[1])) {
+    if args.len() >= 2 && args[0].ends_with(&executable_name(&args[1])) {
         args.remove(1);
     }
 


### PR DESCRIPTION
External tools which extend Cargo with [custom subcommands](https://doc.rust-lang.org/cargo/reference/external-tools.html#custom-subcommands) get called with the name of the subcommand as the first argument.

If it is desired for the external tool to also be callable separately, it is useful to remove this first argument if it exists, so no repetition of the subcommand name takes place.

The code which makes sure this happens works like a charm on Linux, but on Windows, executables usually carry the ".exe" file extension, which made the current solution not compatible with Windows.

Now cargo-guppy can also be called as a custom Cargo subcommand on Windows.