### PR TITLE
upgrade to cargo 0.52.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,12 +145,13 @@ dependencies = [
 [[package]]
 name = "cargo"
 version = "0.52.0"
-source = "git+https://github.com/rust-lang/cargo.git?branch=rust-1.51.0#43b129a20fbf1ede0df411396ccf0c024bf34134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668794d3757557250a8b7bf7d0920ca60910d9635e76d008caed037ec25c39b3"
 dependencies = [
  "anyhow",
  "atty",
  "bytesize",
- "cargo-platform 0.1.1 (git+https://github.com/rust-lang/cargo.git?branch=rust-1.51.0)",
+ "cargo-platform",
  "clap",
  "core-foundation",
  "crates-io",
@@ -246,21 +247,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-platform"
-version = "0.1.1"
-source = "git+https://github.com/rust-lang/cargo.git?branch=rust-1.51.0#43b129a20fbf1ede0df411396ccf0c024bf34134"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "cargo_metadata"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
 dependencies = [
  "camino",
- "cargo-platform 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-platform",
  "semver 0.11.0",
  "semver-parser 0.10.2",
  "serde",
@@ -399,7 +392,8 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 [[package]]
 name = "crates-io"
 version = "0.33.0"
-source = "git+https://github.com/rust-lang/cargo.git?branch=rust-1.51.0#43b129a20fbf1ede0df411396ccf0c024bf34134"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217138863f33507d7a8edef10fc673c4911679ef7aeb9ff53ee7bb82dc7bf590"
 dependencies = [
  "anyhow",
  "curl",

--- a/guppy-summaries/src/summary.rs
+++ b/guppy-summaries/src/summary.rs
@@ -55,7 +55,7 @@ impl<M> SummaryWithMetadata<M> {
     where
         M: Deserialize<'de>,
     {
-        Ok(toml::from_str(s)?)
+        toml::from_str(s)
     }
 
     /// Perform a diff of this summary against another.

--- a/guppy/src/graph/cargo/cargo_api.rs
+++ b/guppy/src/graph/cargo/cargo_api.rs
@@ -182,7 +182,7 @@ impl<'a> Default for CargoOptions<'a> {
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum CargoResolverVersion {
-    /// The default "classic" feature resolver in Rust.
+    /// The "classic" feature resolver in Rust.
     ///
     /// This feature resolver unifies features across inactive platforms, and also unifies features
     /// across normal, build and dev dependencies for initials. This may produce results that are
@@ -200,18 +200,15 @@ pub enum CargoResolverVersion {
     /// in the Cargo reference.
     V1Install,
 
-    /// The new feature resolver. This feature resolver does not unify features:
+    /// [Version 2 of the feature resolver](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2),
+    /// available since Rust 1.51. This feature resolver does not unify features:
     ///
     /// * across host (build) and target (regular) dependencies
     /// * with dev-dependencies for initials, if tests aren't currently being built
     /// * with [platform-specific dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies) that are currently inactive
     ///
-    /// This is currently available as `-Zfeatures=all`, and is expected to be released in a future
-    /// version of Cargo.
-    ///
-    /// For more, see
-    /// [Features](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#features) in the
-    /// Cargo reference.
+    /// Version 2 of the feature resolver can be enabled by specifying `resolver = "2"` in the
+    /// workspace's `Cargo.toml`.
     V2,
 }
 

--- a/internal-tools/cargo-compare/Cargo.toml
+++ b/internal-tools/cargo-compare/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.39"
-# TODO: update to cargo 0.52.0 when it comes out
-cargo = { git = "https://github.com/rust-lang/cargo.git", branch = "rust-1.51.0" }
+cargo = "0.52.0"
 diffus = "0.9.1"
 either = "1.6.1"
 itertools = "0.10.0"

--- a/tools/determinator/src/rules.rs
+++ b/tools/determinator/src/rules.rs
@@ -167,7 +167,7 @@ macro_rules! doc_comment {
 impl DeterminatorRules {
     /// Deserializes determinator rules from the given TOML string.
     pub fn parse(s: &str) -> Result<Self, toml::de::Error> {
-        Ok(toml::from_str(s)?)
+        toml::from_str(s)
     }
 
     doc_comment! {


### PR DESCRIPTION
Ships with Rust 1.51, which has the new feature resolver.