### PR TITLE
[hakari] fix packages missing in an edge case

### DIFF
--- a/tools/cargo-hakari/CHANGELOG.md
+++ b/tools/cargo-hakari/CHANGELOG.md
@@ -8,6 +8,10 @@
   - This is a temporary workaround until [Cargo issue #9052](https://github.com/rust-lang/cargo/issues/9052) is resolved.
 - Enable ANSI color output on Windows.
 
+### Fixed
+
+- Fixed some workspace-hack contents missing in an edge case.
+
 ### Optimized
 
 - An [algorithmic improvement](https://github.com/facebookincubator/cargo-guppy/pull/468) in `hakari` makes computation up to 33% faster.

--- a/tools/hakari/CHANGELOG.md
+++ b/tools/hakari/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Support for alternate registries through the `[registries]` section in the config.
   - This is a temporary workaround until [Cargo issue #9052](https://github.com/rust-lang/cargo/issues/9052) is resolved.
 
+### Fixed
+
+- Fixed some workspace-hack contents missing in an edge case.
+
 ### Optimized
 
 - An [algorithmic improvement](https://github.com/facebookincubator/cargo-guppy/pull/468) makes computation up to 33% faster.

--- a/tools/hakari/src/lib.rs
+++ b/tools/hakari/src/lib.rs
@@ -145,7 +145,9 @@ pub mod internals {
     //!
     //! These are provided in case some post-processing needs to be done.
 
-    pub use crate::hakari::{ComputedInnerMap, ComputedMap, ComputedValue, OutputKey, OutputMap};
+    pub use crate::hakari::{
+        ComputedInnerMap, ComputedInnerValue, ComputedMap, ComputedValue, OutputKey, OutputMap,
+    };
 }
 
 /// Re-export diffy.

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -36,6 +36,7 @@ libz-sys = { version = "1.1.3", default-features = false, features = ["libc"] }
 proc-macro2 = { version = "1.0.29", features = ["proc-macro"] }
 quote = { version = "1.0.10", features = ["proc-macro"] }
 semver = { version = "1.0.4", features = ["serde", "std"] }
+serde = { version = "1.0.130", features = ["derive", "serde_derive", "std"] }
 syn = { version = "1.0.78", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]


### PR DESCRIPTION
It's a bit hard to explain, but we were trying to take a shortcut here
by not using the full `ComputedMap` machinery -- that backfired in cases
where the map transitioned away from SingleTarget to
SingleTargetSingleHost. Using the full machinery fixes this.