### PR TITLE
Add rust-version support to PackageMetadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c297bd3135f558552f99a0daa180876984ea2c4ffa7470314540dff8c654109a"
+checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
 dependencies = [
  "camino",
  "cargo-platform",

--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -33,7 +33,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 camino = "1.0.5"
-cargo_metadata = "0.14.0"
+cargo_metadata = "0.14.1"
 debug-ignore = "1.0.1"
 guppy-summaries = { version = "0.5.1", path = "../guppy-summaries", optional = true }
 fixedbitset = { version = "0.4.0", default-features = false }

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -291,6 +291,7 @@ impl<'a> GraphBuildState<'a> {
                 metadata_table: package.metadata,
                 links: package.links.map(|s| s.into()),
                 publish: PackagePublishImpl::new(package.publish),
+                rust_version: package.rust_version,
                 features,
 
                 package_ix,

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -854,6 +854,16 @@ impl<'g> PackageMetadata<'g> {
         PackagePublish::new(&self.inner.publish)
     }
 
+    /// Returns the minimal Rust compiler version, which should be able to compile the package, if
+    /// specified.
+    ///
+    /// This is the same as the `rust-version` field of `Cargo.toml`. For more, see [the
+    /// `rust-version` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+    /// in the Cargo reference.
+    pub fn rust_version(&self) -> Option<&'g VersionReq> {
+        self.inner.rust_version.as_ref()
+    }
+
     /// Returns all the build targets for this package.
     ///
     /// For more, see [Cargo
@@ -1019,6 +1029,7 @@ pub(crate) struct PackageMetadataImpl {
     pub(super) metadata_table: JsonValue,
     pub(super) links: Option<Box<str>>,
     pub(super) publish: PackagePublishImpl,
+    pub(super) rust_version: Option<VersionReq>,
     // Some(...) means named feature with listed dependencies.
     // None means an optional dependency.
     pub(super) features: IndexMap<Box<str>, Option<Vec<String>>>,


### PR DESCRIPTION
The package.rust-version field was added to Cargo in Rust 1.56. When a package author specifies this field, they promise the package can be compiled with at least the specified Rust version.

The cargo_metadata crate was bumped from 0.14.0 to 0.14.1, since that's the first version of cargo_metadata which added support for the `rust-version` field.

I would be more than happy to add test cases, as requested in the contributor guidelines, but wasn't entirely sure where the best place would be (I couldn't find tests for the other PackageMetadata fields to use as a reference). Possibly I could add a test module for package metadata tests in `guppy::unit_tests`, and then mock the dependencies for PackageMetadata.