### PR TITLE
 [guppy] use forward slashes for relative paths on all platforms, including Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ version = "0.11.3"
 dependencies = [
  "camino",
  "cargo_metadata",
+ "cfg-if",
  "debug-ignore",
  "fixedbitset",
  "fixtures",

--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -34,6 +34,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 camino = "1.0.5"
 cargo_metadata = "0.14.1"
+cfg-if = "1.0.0"
 debug-ignore = "1.0.1"
 guppy-summaries = { version = "0.5.1", path = "../guppy-summaries", optional = true }
 fixedbitset = { version = "0.4.0", default-features = false }

--- a/guppy/src/graph/summaries/package_set.rs
+++ b/guppy/src/graph/summaries/package_set.rs
@@ -371,7 +371,7 @@ struct ThirdPartySelectFields<'a> {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        with = "opt_path_fwdslash"
+        serialize_with = "serialize_opt_path_fwdslash"
     )]
     path: Option<Utf8PathBuf>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -544,26 +544,16 @@ impl Serialize for ThirdPartySummary {
     }
 }
 
-mod opt_path_fwdslash {
-    use super::*;
-    use guppy_summaries::path_forward_slashes;
-
-    pub fn serialize<S>(path: &Option<Utf8PathBuf>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match path {
-            Some(path) => path_forward_slashes::serialize(path, serializer),
-            None => serializer.serialize_none(),
-        }
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Utf8PathBuf>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(Option::<Utf8PathBuf>::deserialize(deserializer)?
-            .map(path_forward_slashes::de_replace_slashes))
+fn serialize_opt_path_fwdslash<S>(
+    path: &Option<Utf8PathBuf>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match path {
+        Some(path) => guppy_summaries::serialize_forward_slashes(path, serializer),
+        None => serializer.serialize_none(),
     }
 }
 

--- a/tools/determinator/src/determinator.rs
+++ b/tools/determinator/src/determinator.rs
@@ -62,8 +62,8 @@ impl<'g, 'a> Determinator<'g, 'a> {
     /// Adds a list of changed paths. This list is used as a source of information for the
     /// determinator.
     ///
-    /// This should consist of paths that are changed since the base revision, and should use the
-    /// canonical separator for the platform (e.g. `/` on Unix platforms and `\` on Windows).
+    /// This should consist of paths that are changed since the base revision. Paths on Windows may
+    /// use either `/` or `\\` as separators.
     ///
     /// [`Utf8Paths0`](crate::Utf8Paths0) in this crate provides a convenient way to handle
     /// null-separated paths as produced by source control systems.

--- a/tools/hakari/src/toml_out.rs
+++ b/tools/hakari/src/toml_out.rs
@@ -307,10 +307,8 @@ pub(crate) fn write_toml(
                                     package_id: dep.id().clone(),
                                     rel_path: path.to_path_buf(),
                                 })?;
-                            let rel_path = pathdiff::diff_paths(path, hakari_path)
-                                .expect("both hakari_path and path are relative");
-                            Utf8PathBuf::from_path_buf(rel_path)
-                                .expect("both path and hakari_path are UTF-8 so this is as well")
+                            pathdiff::diff_utf8_paths(path, hakari_path)
+                                .expect("both hakari_path and path are relative")
                         };
 
                         let path_str = path_out.as_str();


### PR DESCRIPTION
Use forward slashes for *relative* paths while continuing to use
canonical separators for absolute paths. This keeps the internal logic
simpler.