### PR TITLE
[target-spec] bump to cfg-expr 0.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,9 +202,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions-rs/toolchain@v1
         with:
-          # 1.54 is the cfg-expr version
+          # 1.58 is the cfg-expr version
           # TODO: why is there no way to specify this as a global variable in GHA?
-          toolchain: 1.54
+          toolchain: 1.58
           override: true
       - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
       - name: Build and test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edae0b9625d1fce32f7d64b71784d9b1bf8469ec1a9c417e44aaf16a9cbd7571"
+checksum = "ea2d13135dfe0068874088e92b5ab74bdd1942e8f6c567006dbdc23a9b27a9b0"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -2125,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "target-spec"

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['powerpc64-unknown-freebsd', 'thumbv7neon-unknown-linux-musleabihf']
+# platforms = ['powerpc-wrs-vxworks', 'thumbv7neon-unknown-linux-gnueabihf']
 # [[traversal-excludes.ids]]
 # name = 'cargo-compare'
 # version = '0.1.0'

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['aarch64-unknown-linux-gnu_ilp32', 'armv7-unknown-linux-gnueabi']
+# platforms = ['aarch64-unknown-linux-gnu', 'armv7-unknown-linux-gnueabi']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-7.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['wasm32-unknown-emscripten', 'riscv32gc-unknown-linux-gnu', 'thumbv7em-none-eabi']
+# platforms = ['thumbv8m.main-none-eabihf', 'powerpc64le-unknown-linux-gnu', 'thumbv7a-pc-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'cargo-compare'
 # version = '0.1.0'

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-1.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['powerpc64-unknown-freebsd', 's390x-unknown-linux-gnu', 'mipsisa64r6-unknown-linux-gnuabi64']
+# platforms = ['powerpc-wrs-vxworks-spe', 'riscv64gc-unknown-none-elf', 'mipsisa32r6el-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'pathdiff'
 # version = '0.2.0'
@@ -59,22 +59,16 @@ proc-macro2 = { version = "1", features = ["proc-macro"] }
 quote = { version = "1", features = ["proc-macro"] }
 syn = { version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 
-[target.powerpc64-unknown-freebsd.dependencies]
+[target.powerpc-wrs-vxworks-spe.dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.powerpc64-unknown-freebsd.build-dependencies]
+[target.powerpc-wrs-vxworks-spe.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.s390x-unknown-linux-gnu.dependencies]
+[target.mipsisa32r6el-unknown-linux-gnu.dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.s390x-unknown-linux-gnu.build-dependencies]
-libc = { version = "0.2", features = ["std"] }
-
-[target.mipsisa64r6-unknown-linux-gnuabi64.dependencies]
-libc = { version = "0.2", features = ["std"] }
-
-[target.mipsisa64r6-unknown-linux-gnuabi64.build-dependencies]
+[target.mipsisa32r6el-unknown-linux-gnu.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['powerpc-unknown-linux-gnuspe', 'x86_64-unknown-redox', 'aarch64_be-unknown-linux-gnu']
+# platforms = ['powerpc-unknown-linux-gnu', 'x86_64-unknown-redox', 'aarch64_be-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'fixtures'
 # version = '0.1.0'
@@ -74,10 +74,10 @@ proc-macro2 = { version = "1", features = ["proc-macro"] }
 quote = { version = "1", features = ["proc-macro"] }
 syn = { version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 
-[target.powerpc-unknown-linux-gnuspe.dependencies]
+[target.powerpc-unknown-linux-gnu.dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.powerpc-unknown-linux-gnuspe.build-dependencies]
+[target.powerpc-unknown-linux-gnu.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
 [target.x86_64-unknown-redox.dependencies]

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-5.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['sparc64-unknown-netbsd', 'x86_64-unknown-illumos', 'riscv64gc-unknown-linux-gnu']
+# platforms = ['sparc-unknown-linux-gnu', 'x86_64-unknown-l4re-uclibc', 'riscv32imac-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'bytesize'
 # version = '1.0.1'
@@ -58,22 +58,16 @@ proc-macro2 = { version = "1", features = ["proc-macro"] }
 quote = { version = "1", features = ["proc-macro"] }
 syn = { version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 
-[target.sparc64-unknown-netbsd.dependencies]
+[target.sparc-unknown-linux-gnu.dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.sparc64-unknown-netbsd.build-dependencies]
+[target.sparc-unknown-linux-gnu.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.x86_64-unknown-illumos.dependencies]
+[target.x86_64-unknown-l4re-uclibc.dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.x86_64-unknown-illumos.build-dependencies]
-libc = { version = "0.2", features = ["std"] }
-
-[target.riscv64gc-unknown-linux-gnu.dependencies]
-libc = { version = "0.2", features = ["std"] }
-
-[target.riscv64gc-unknown-linux-gnu.build-dependencies]
+[target.x86_64-unknown-l4re-uclibc.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-6.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-6.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['i386-apple-ios', 'armv7a-none-eabihf']
+# platforms = ['bpfel-unknown-none', 'armv7a-kmc-solid_asp3-eabi']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]
@@ -61,12 +61,6 @@ regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode
 serde = { version = "1", features = ["derive", "serde_derive", "std"] }
 serde_json = { version = "1", features = ["raw_value", "std"] }
 syn = { version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
-
-[target.i386-apple-ios.dependencies]
-libc = { version = "0.2", features = ["std"] }
-
-[target.i386-apple-ios.build-dependencies]
-libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-7.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['armv7s-apple-ios', 'armv7-unknown-linux-gnueabihf']
+# platforms = ['armv7r-none-eabi', 'armv7-unknown-linux-gnueabihf']
 # [[traversal-excludes.ids]]
 # name = 'ascii'
 # version = '0.9.3'
@@ -76,12 +76,6 @@ serde_json = { version = "1", features = ["raw_value", "std"] }
 [build-dependencies]
 proc-macro2 = { version = "1", features = ["proc-macro"] }
 quote = { version = "1", features = ["proc-macro"] }
-
-[target.armv7s-apple-ios.dependencies]
-libc = { version = "0.2", features = ["std"] }
-
-[target.armv7s-apple-ios.build-dependencies]
-libc = { version = "0.2", features = ["std"] }
 
 [target.armv7-unknown-linux-gnueabihf.dependencies]
 libc = { version = "0.2", features = ["std"] }

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['x86_64-wrs-vxworks', 'arm-linux-androideabi']
+# platforms = ['x86_64-wrs-vxworks', 'aarch64_be-unknown-linux-gnu_ilp32']
 # [[traversal-excludes.ids]]
 # name = 'bit-set'
 # version = '0.5.2'
@@ -65,7 +65,7 @@ syn = { version = "1", features = ["clone-impls", "derive", "full", "parsing", "
 [target.x86_64-wrs-vxworks.dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.arm-linux-androideabi.dependencies]
+[target.aarch64_be-unknown-linux-gnu_ilp32.dependencies]
 libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-1.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['x86_64-apple-darwin']
+# platforms = ['wasm64-unknown-unknown']
 # [[traversal-excludes.ids]]
 # name = 'byteorder'
 # version = '1.3.4'
@@ -197,16 +197,11 @@ unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 version_check = { version = "0.9", default-features = false }
 
-[target.x86_64-apple-darwin.dependencies]
-commoncrypto = { version = "0.2", default-features = false }
-commoncrypto-sys = { version = "0.2", default-features = false }
-core-foundation = { version = "0.7", default-features = false, features = ["mac_os_10_7_support"] }
-core-foundation-sys = { version = "0.7", default-features = false, features = ["mac_os_10_7_support"] }
+[target.wasm64-unknown-unknown.dependencies]
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+openssl = { version = "0.10", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
-termios = { version = "0.3", default-features = false }
-
-[target.x86_64-apple-darwin.build-dependencies]
-libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-6.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-6.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['i686-unknown-freebsd', 'thumbv7em-none-eabihf', 'riscv32gc-unknown-linux-musl']
+# platforms = ['i686-pc-windows-gnu', 'thumbv7a-uwp-windows-msvc', 'powerpc64le-unknown-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'cargo-platform'
 # version = '0.1.1'
@@ -346,7 +346,46 @@ vte = { version = "0.3", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
 
-[target.i686-unknown-freebsd.dependencies]
+[target.i686-pc-windows-gnu.dependencies]
+encode_unicode = { version = "0.3", features = ["std"] }
+fwdansi = { version = "1", default-features = false }
+miow = { version = "0.3", default-features = false }
+output_vt100 = { version = "0.1", default-features = false }
+winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntstatus", "processenv", "processthreadsapi", "profileapi", "psapi", "schannel", "securitybaseapi", "shellapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip"] }
+winapi-i686-pc-windows-gnu = { version = "0.4", default-features = false }
+winapi-util = { version = "0.1", default-features = false }
+
+[target.i686-pc-windows-gnu.build-dependencies]
+ctor = { version = "0.1", default-features = false }
+encode_unicode = { version = "0.3", features = ["std"] }
+fwdansi = { version = "1", default-features = false }
+miow = { version = "0.3", default-features = false }
+output_vt100 = { version = "0.1", default-features = false }
+winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntstatus", "processenv", "processthreadsapi", "profileapi", "psapi", "schannel", "securitybaseapi", "shellapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip"] }
+winapi-i686-pc-windows-gnu = { version = "0.4", default-features = false }
+winapi-util = { version = "0.1", default-features = false }
+
+[target.thumbv7a-uwp-windows-msvc.dependencies]
+encode_unicode = { version = "0.3", features = ["std"] }
+fwdansi = { version = "1", default-features = false }
+miow = { version = "0.3", default-features = false }
+output_vt100 = { version = "0.1", default-features = false }
+schannel = { version = "0.1", default-features = false }
+winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntstatus", "processenv", "processthreadsapi", "profileapi", "psapi", "schannel", "securitybaseapi", "shellapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip"] }
+winapi-util = { version = "0.1", default-features = false }
+
+[target.thumbv7a-uwp-windows-msvc.build-dependencies]
+ctor = { version = "0.1", default-features = false }
+encode_unicode = { version = "0.3", features = ["std"] }
+fwdansi = { version = "1", default-features = false }
+miow = { version = "0.3", default-features = false }
+output_vt100 = { version = "0.1", default-features = false }
+schannel = { version = "0.1", default-features = false }
+vcpkg = { version = "0.2", default-features = false }
+winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntstatus", "processenv", "processthreadsapi", "profileapi", "psapi", "schannel", "securitybaseapi", "shellapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip"] }
+winapi-util = { version = "0.1", default-features = false }
+
+[target.powerpc64le-unknown-linux-musl.dependencies]
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 openssl = { version = "0.10", default-features = false }
@@ -354,35 +393,7 @@ openssl-probe = { version = "0.1", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
 termios = { version = "0.3", default-features = false }
 
-[target.i686-unknown-freebsd.build-dependencies]
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-openssl = { version = "0.10", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
-termios = { version = "0.3", default-features = false }
-
-[target.thumbv7em-none-eabihf.dependencies]
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-openssl = { version = "0.10", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
-
-[target.thumbv7em-none-eabihf.build-dependencies]
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-openssl = { version = "0.10", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
-
-[target.riscv32gc-unknown-linux-musl.dependencies]
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-openssl = { version = "0.10", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
-termios = { version = "0.3", default-features = false }
-
-[target.riscv32gc-unknown-linux-musl.build-dependencies]
+[target.powerpc64le-unknown-linux-musl.build-dependencies]
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 openssl = { version = "0.10", default-features = false }

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-7.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['i686-apple-darwin']
+# platforms = ['i586-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'crossbeam-channel'
 # version = '0.4.4'
@@ -221,14 +221,14 @@ unicode-segmentation = { version = "1", default-features = false }
 unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 
-[target.i686-apple-darwin.dependencies]
-commoncrypto = { version = "0.2", default-features = false }
-commoncrypto-sys = { version = "0.2", default-features = false }
-core-foundation = { version = "0.7", default-features = false, features = ["mac_os_10_7_support"] }
-core-foundation-sys = { version = "0.7", default-features = false, features = ["mac_os_10_7_support"] }
+[target.i586-unknown-linux-gnu.dependencies]
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+openssl = { version = "0.10", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
 
-[target.i686-apple-darwin.build-dependencies]
+[target.i586-unknown-linux-gnu.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['aarch64-unknown-freebsd', 'i686-unknown-openbsd', 'x86_64-unknown-linux-gnu']
+# platforms = ['aarch64-unknown-freebsd', 'i686-unknown-linux-musl', 'x86_64-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'cargo-compare'
 # version = '0.1.0'
@@ -146,7 +146,7 @@ ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "s
 rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
 termios = { version = "0.3", default-features = false }
 
-[target.i686-unknown-openbsd.dependencies]
+[target.i686-unknown-linux-musl.dependencies]
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
 termios = { version = "0.3", default-features = false }

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-5.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['riscv32i-unknown-none-elf', 'i686-unknown-linux-gnu', 'armv7-unknown-linux-gnueabihf']
+# platforms = ['riscv32gc-unknown-linux-gnu', 'i686-unknown-freebsd', 'armv7-unknown-linux-gnueabi']
 # [[traversal-excludes.ids]]
 # name = 'atty'
 # version = '0.2.14'
@@ -217,20 +217,28 @@ unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 version_check = { version = "0.9", default-features = false }
 
-[target.i686-unknown-linux-gnu.dependencies]
+[target.riscv32gc-unknown-linux-gnu.dependencies]
 openssl-probe = { version = "0.1", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
 termios = { version = "0.3", default-features = false }
 
-[target.i686-unknown-linux-gnu.build-dependencies]
+[target.riscv32gc-unknown-linux-gnu.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.armv7-unknown-linux-gnueabihf.dependencies]
+[target.i686-unknown-freebsd.dependencies]
 openssl-probe = { version = "0.1", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
 termios = { version = "0.3", default-features = false }
 
-[target.armv7-unknown-linux-gnueabihf.build-dependencies]
+[target.i686-unknown-freebsd.build-dependencies]
+libc = { version = "0.2", features = ["std"] }
+
+[target.armv7-unknown-linux-gnueabi.dependencies]
+openssl-probe = { version = "0.1", default-features = false }
+openssl-sys = { version = "0.9", default-features = false }
+termios = { version = "0.3", default-features = false }
+
+[target.armv7-unknown-linux-gnueabi.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-6.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-6.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['thumbv8m.main-none-eabi', 'riscv32imac-unknown-none-elf', 'aarch64-unknown-freebsd']
+# platforms = ['thumbv7neon-unknown-linux-musleabihf', 'riscv32i-unknown-none-elf', 'aarch64-pc-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'anyhow'
 # version = '1.0.33'
@@ -160,8 +160,17 @@ unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 version_check = { version = "0.9", default-features = false }
 
-[target.aarch64-unknown-freebsd.dependencies]
+[target.thumbv7neon-unknown-linux-musleabihf.dependencies]
 termios = { version = "0.3", default-features = false }
+
+[target.aarch64-pc-windows-msvc.dependencies]
+encode_unicode = { version = "0.3", features = ["std"] }
+output_vt100 = { version = "0.1", default-features = false }
+winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "minwinbase", "minwindef", "ntdef", "processenv", "profileapi", "std", "sysinfoapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winuser"] }
+winapi-util = { version = "0.1", default-features = false }
+
+[target.aarch64-pc-windows-msvc.build-dependencies]
+ctor = { version = "0.1", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-7.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['riscv32imc-unknown-none-elf', 'i586-pc-windows-msvc', 'riscv32i-unknown-none-elf']
+# platforms = ['riscv32i-unknown-none-elf', 'hexagon-unknown-linux-musl', 'riscv32gc-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'foreign-types-shared'
 # version = '0.1.1'
@@ -64,8 +64,17 @@ proc-macro2 = { version = "1", features = ["proc-macro"] }
 quote = { version = "1", features = ["proc-macro"] }
 syn = { version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 
-[target.i586-pc-windows-msvc.dependencies]
-winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntstatus", "processenv", "processthreadsapi", "profileapi", "psapi", "schannel", "securitybaseapi", "shellapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip"] }
+[target.hexagon-unknown-linux-musl.dependencies]
+libc = { version = "0.2", features = ["std"] }
+
+[target.hexagon-unknown-linux-musl.build-dependencies]
+libc = { version = "0.2", features = ["std"] }
+
+[target.riscv32gc-unknown-linux-gnu.dependencies]
+libc = { version = "0.2", features = ["std"] }
+
+[target.riscv32gc-unknown-linux-gnu.build-dependencies]
+libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'mips64-unknown-linux-muslabi64'
+triple = 'mips-unknown-linux-uclibc'
 target-features = ['bmi1', 'xsaveopt']
 [[metadata.omitted-packages.ids]]
 name = 'guppy-summaries'

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-3.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-3.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'mipsisa64r6-unknown-linux-gnuabi64'
+triple = 'mipsisa32r6el-unknown-linux-gnu'
 target-features = ['sse2', 'sse3']
 flags = ['abc', 'cargo_web']
 

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-4.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-4.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'powerpc-wrs-vxworks-spe'
+triple = 'powerpc-unknown-openbsd'
 target-features = ['avx2', 'bmi2', 'fma', 'sse', 'sse3', 'xsaveopt']
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'riscv64gc-unknown-linux-musl'
+triple = 'riscv32imc-unknown-none-elf'
 target-features = 'unknown'
 flags = ['abc', 'foo']
 

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-6.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-6.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armebv7r-none-eabihf'
+triple = 'armebv7r-none-eabi'
 target-features = 'unknown'
 flags = ['bar', 'cargo_web']
 
 [metadata.target-platform]
-triple = 'powerpc-unknown-linux-gnu'
+triple = 'nvptx64-nvidia-cuda'
 target-features = []
 flags = ['flag-test']
 

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-7.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-7.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'powerpc64-unknown-freebsd'
+triple = 'powerpc-wrs-vxworks'
 target-features = 'unknown'
 flags = ['flag-test']
 
 [metadata.target-platform]
-triple = 'i686-uwp-windows-msvc'
+triple = 'i686-unknown-uefi'
 target-features = ['aes', 'sse3', 'ssse3', 'xsave']
 flags = ['flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'hexagon-unknown-linux-musl'
+triple = 'bpfeb-unknown-none'
 target-features = ['bmi1', 'sse3', 'sse4.2']
 
 [[host-package]]

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-1.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'powerpc64le-unknown-linux-musl'
+triple = 'powerpc64le-unknown-freebsd'
 target-features = 'all'
 flags = ['bar', 'foo']
 
 [metadata.target-platform]
-triple = 'mipsisa32r6-unknown-linux-gnu'
+triple = 'mipsel-unknown-linux-uclibc'
 target-features = 'all'
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-2.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'powerpc64le-unknown-linux-musl'
+triple = 'powerpc64le-unknown-freebsd'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'textwrap'

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-3.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv7-unknown-linux-musleabi'
+triple = 'armv7-unknown-linux-gnueabihf'
 target-features = 'unknown'
 flags = ['bar', 'foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-6.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'thumbv7em-none-eabihf'
+triple = 'thumbv7a-uwp-windows-msvc'
 target-features = ['aes', 'bmi1', 'xsaves']
 flags = ['foo']
 

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-7.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-7.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'mipsel-unknown-linux-uclibc'
+triple = 'mipsel-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-0.toml
@@ -12,7 +12,7 @@ target-features = 'all'
 flags = ['cargo_web']
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-uefi'
+triple = 'x86_64-unknown-redox'
 target-features = 'unknown'
 flags = ['flag-test', 'test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-1.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'sparc64-unknown-netbsd'
+triple = 's390x-unknown-linux-musl'
 target-features = ['avx', 'bmi2', 'rdrand', 'sse', 'sse2']
 flags = ['abc', 'test-flag']
 

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-2.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-2.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-linux-musl'
+triple = 'riscv32imc-unknown-none-elf'
 target-features = 'unknown'
 flags = ['foo']
 
@@ -493,13 +493,6 @@ features = []
 [[host-package]]
 name = 'terminal_size'
 version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'termios'
-version = '0.3.2'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-6.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'mips-unknown-linux-musl'
+triple = 'i686-wrs-vxworks'
 target-features = 'unknown'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-linux-gnux32'
+triple = 'x86_64-unknown-linux-musl'
 target-features = 'unknown'
 flags = ['test-flag']
 

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-5.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-5.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'x86_64-pc-windows-gnu'
+triple = 'x86_64-pc-solaris'
 target-features = 'all'
 flags = ['bar']
 

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-6.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-6.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i686-pc-windows-msvc'
+triple = 'i686-linux-android'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/large/hakari/metadata_libra-5.toml
+++ b/fixtures/large/hakari/metadata_libra-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['x86_64-fuchsia', 'aarch64_be-unknown-linux-gnu', 'aarch64-linux-android']
+# platforms = ['x86_64-fuchsia', 'aarch64-wrs-vxworks', 'aarch64-linux-android']
 # [[traversal-excludes.ids]]
 # name = 'adler32'
 # version = '1.0.3'
@@ -120,10 +120,10 @@ lazy_static = { version = "1", default-features = false, features = ["spin", "sp
 [target.x86_64-fuchsia.build-dependencies]
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 
-[target.aarch64_be-unknown-linux-gnu.dependencies]
+[target.aarch64-wrs-vxworks.dependencies]
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 
-[target.aarch64_be-unknown-linux-gnu.build-dependencies]
+[target.aarch64-wrs-vxworks.build-dependencies]
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 
 [target.aarch64-linux-android.dependencies]

--- a/fixtures/large/hakari/metadata_libra-6.toml
+++ b/fixtures/large/hakari/metadata_libra-6.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['msp430-none-elf']
+# platforms = ['mipsisa64r6el-unknown-linux-gnuabi64']
 # [[traversal-excludes.ids]]
 # name = 'error-chain'
 # version = '0.12.1'
@@ -719,17 +719,29 @@ xml-rs = { version = "0.8", default-features = false }
 yamux = { version = "0.2", default-features = false }
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
-[target.msp430-none-elf.dependencies]
+[target.mipsisa64r6el-unknown-linux-gnuabi64.dependencies]
 ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
+mio-uds = { version = "0.6", default-features = false }
+nix = { version = "0.14", default-features = false }
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
+tokio-signal = { version = "0.2", default-features = false }
+tokio-uds = { version = "0.2", default-features = false }
+utf8parse = { version = "0.1", default-features = false }
+void = { version = "1", features = ["std"] }
 
-[target.msp430-none-elf.build-dependencies]
+[target.mipsisa64r6el-unknown-linux-gnuabi64.build-dependencies]
 ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
+mio-uds = { version = "0.6", default-features = false }
+nix = { version = "0.14", default-features = false }
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
+tokio-signal = { version = "0.2", default-features = false }
+tokio-uds = { version = "0.2", default-features = false }
+utf8parse = { version = "0.1", default-features = false }
+void = { version = "1", features = ["std"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra-7.toml
+++ b/fixtures/large/hakari/metadata_libra-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['x86_64-apple-ios', 'bpfeb-unknown-none']
+# platforms = ['x86_64-apple-darwin', 'asmjs-unknown-emscripten']
 # [[traversal-excludes.ids]]
 # name = 'multimap'
 # version = '0.4.0'
@@ -233,7 +233,7 @@ rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", defau
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
 rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
-rand_hc = { version = "0.1", default-features = false }
+rand_hc-c65f7effa3be6d31 = { package = "rand_hc", version = "0.1", default-features = false }
 rand_isaac = { version = "0.1", default-features = false }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
 rand_os-c65f7effa3be6d31 = { package = "rand_os", version = "0.1", default-features = false }
@@ -463,7 +463,7 @@ version_check = { version = "0.1", default-features = false }
 walkdir = { version = "2", default-features = false }
 which = { version = "2", default-features = false }
 
-[target.x86_64-apple-ios.dependencies]
+[target.x86_64-apple-darwin.dependencies]
 ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
@@ -477,24 +477,26 @@ tokio-uds = { version = "0.2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
-[target.x86_64-apple-ios.build-dependencies]
+[target.x86_64-apple-darwin.build-dependencies]
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
 
-[target.bpfeb-unknown-none.dependencies]
+[target.asmjs-unknown-emscripten.dependencies]
 ansi_term = { version = "0.11", default-features = false }
-c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
-ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
-rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
+mio-uds = { version = "0.6", default-features = false }
+nix = { version = "0.14", default-features = false }
+rand_hc-6f8ce4dd05d13bba = { package = "rand_hc", version = "0.2", default-features = false }
+tokio-signal = { version = "0.2", default-features = false }
+tokio-uds = { version = "0.2", default-features = false }
+utf8parse = { version = "0.1", default-features = false }
+void = { version = "1", features = ["std"] }
 
-[target.bpfeb-unknown-none.build-dependencies]
-c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
+[target.asmjs-unknown-emscripten.build-dependencies]
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
-ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
-rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
+rand_hc-6f8ce4dd05d13bba = { package = "rand_hc", version = "0.2", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-1.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['riscv64imac-unknown-none-elf']
+# platforms = ['riscv64gc-unknown-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'csv-core'
 # version = '0.1.10'
@@ -113,8 +113,8 @@ crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque
 crossbeam-channel = { version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
 crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
-crossbeam-queue = { version = "0.2", features = ["std"] }
-crossbeam-utils = { version = "0.7", features = ["lazy_static", "std"] }
+crossbeam-queue-6f8ce4dd05d13bba = { package = "crossbeam-queue", version = "0.2", features = ["std"] }
+crossbeam-utils-ca01ad9e24f5d932 = { package = "crossbeam-utils", version = "0.7", features = ["lazy_static", "std"] }
 crunchy = { version = "0.2", features = ["limit_128"] }
 crypto-mac = { version = "0.7", default-features = false }
 csv = { version = "1", default-features = false }
@@ -488,8 +488,8 @@ crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque
 crossbeam-channel = { version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
 crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
-crossbeam-queue = { version = "0.2", features = ["std"] }
-crossbeam-utils = { version = "0.7", features = ["lazy_static", "std"] }
+crossbeam-queue-6f8ce4dd05d13bba = { package = "crossbeam-queue", version = "0.2", features = ["std"] }
+crossbeam-utils-ca01ad9e24f5d932 = { package = "crossbeam-utils", version = "0.7", features = ["lazy_static", "std"] }
 crunchy = { version = "0.2", features = ["limit_128"] }
 crypto-mac = { version = "0.7", default-features = false }
 csv = { version = "1", default-features = false }
@@ -850,35 +850,55 @@ zeroize = { version = "1", default-features = false, features = ["alloc", "zeroi
 zeroize_derive = { version = "1", default-features = false }
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
-[target.riscv64imac-unknown-none-elf.dependencies]
+[target.riscv64gc-unknown-linux-musl.dependencies]
 ansi_term = { version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["bytes", "flate2", "gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
+crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
+crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6", features = ["lazy_static", "std"] }
 encoding_rs = { version = "0.8", default-features = false }
 hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20", features = ["ct-logs", "native-tokio", "rustls-native-certs", "tokio-runtime"] }
 hyper-tls = { version = "0.4", default-features = false }
+mio-uds = { version = "0.6", default-features = false }
 native-tls = { version = "0.2", default-features = false }
+nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
+nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
 openssl-probe = { version = "0.1", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rustls-native-certs = { version = "0.3", default-features = false }
+signal-hook-registry = { version = "1", default-features = false }
 tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
+tokio-signal = { version = "0.2", default-features = false }
 tokio-tls = { version = "0.3", default-features = false }
+tokio-uds = { version = "0.2", default-features = false }
+utf8parse = { version = "0.1", default-features = false }
+void = { version = "1", features = ["std"] }
 
-[target.riscv64imac-unknown-none-elf.build-dependencies]
+[target.riscv64gc-unknown-linux-musl.build-dependencies]
 ansi_term = { version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["bytes", "flate2", "gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
+crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
+crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6", features = ["lazy_static", "std"] }
 encoding_rs = { version = "0.8", default-features = false }
 hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20", features = ["ct-logs", "native-tokio", "rustls-native-certs", "tokio-runtime"] }
 hyper-tls = { version = "0.4", default-features = false }
+mio-uds = { version = "0.6", default-features = false }
 native-tls = { version = "0.2", default-features = false }
+nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
+nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
 openssl-probe = { version = "0.1", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rustls-native-certs = { version = "0.3", default-features = false }
+signal-hook-registry = { version = "1", default-features = false }
 tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
+tokio-signal = { version = "0.2", default-features = false }
 tokio-tls = { version = "0.3", default-features = false }
+tokio-uds = { version = "0.2", default-features = false }
+utf8parse = { version = "0.1", default-features = false }
+void = { version = "1", features = ["std"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-7.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['x86_64-unknown-hermit', 'aarch64_be-unknown-linux-gnu_ilp32', 'thumbv7neon-unknown-linux-gnueabihf']
+# platforms = ['x86_64-unknown-hermit', 'aarch64_be-unknown-linux-gnu_ilp32', 'thumbv7neon-linux-androideabi']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]
@@ -918,13 +918,14 @@ tokio-uds = { version = "0.2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
-[target.thumbv7neon-unknown-linux-gnueabihf.dependencies]
+[target.thumbv7neon-linux-androideabi.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["bytes", "flate2", "gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
 crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
 crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6", features = ["lazy_static", "std"] }
 encoding_rs = { version = "0.8", default-features = false }
+get_if_addrs-sys = { version = "0.1", default-features = false }
 hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20", features = ["ct-logs", "native-tokio", "rustls-native-certs", "tokio-runtime"] }
 hyper-tls = { version = "0.4", default-features = false }
 mio-uds = { version = "0.6", default-features = false }
@@ -944,13 +945,15 @@ tokio-uds = { version = "0.2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
-[target.thumbv7neon-unknown-linux-gnueabihf.build-dependencies]
+[target.thumbv7neon-linux-androideabi.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["bytes", "flate2", "gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
 crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
 crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6", features = ["lazy_static", "std"] }
 encoding_rs = { version = "0.8", default-features = false }
+gcc = { version = "0.3", default-features = false }
+get_if_addrs-sys = { version = "0.1", default-features = false }
 hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20", features = ["ct-logs", "native-tokio", "rustls-native-certs", "tokio-runtime"] }
 hyper-tls = { version = "0.4", default-features = false }
 mio-uds = { version = "0.6", default-features = false }

--- a/fixtures/large/hakari/metadata_libra_f0091a4-0.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['powerpc-unknown-openbsd', 'thumbv7em-none-eabi']
+# platforms = ['powerpc-unknown-linux-musl', 'thumbv7a-pc-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'arrayref'
 # version = '0.3.6'
@@ -130,11 +130,15 @@ syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-i
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 toml = { version = "0.5" }
 
-[target.powerpc-unknown-openbsd.dependencies]
+[target.powerpc-unknown-linux-musl.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
-[target.thumbv7em-none-eabi.dependencies]
+[target.thumbv7a-pc-windows-msvc.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
+winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "ioapiset", "knownfolders", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "schannel", "securitybaseapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winreg", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+
+[target.thumbv7a-pc-windows-msvc.build-dependencies]
+winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "ioapiset", "knownfolders", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "schannel", "securitybaseapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winreg", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_f0091a4-1.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['hexagon-unknown-linux-musl']
+# platforms = ['bpfeb-unknown-none']
 # [[traversal-excludes.ids]]
 # name = 'crossbeam-deque'
 # version = '0.7.2'
@@ -98,12 +98,8 @@ syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-i
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 toml = { version = "0.5" }
 
-[target.hexagon-unknown-linux-musl.dependencies]
+[target.bpfeb-unknown-none.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
-libc = { version = "0.2", features = ["std"] }
-
-[target.hexagon-unknown-linux-musl.build-dependencies]
-libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_f0091a4-5.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['x86_64-unknown-illumos', 'powerpc-wrs-vxworks', 'mipsel-unknown-none']
+# platforms = ['x86_64-unknown-illumos', 'powerpc-unknown-netbsd', 'mipsel-unknown-linux-uclibc']
 # [[traversal-excludes.ids]]
 # name = 'dirs-sys'
 # version = '0.3.4'
@@ -99,10 +99,10 @@ toml = { version = "0.5" }
 [target.x86_64-unknown-illumos.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
-[target.powerpc-wrs-vxworks.dependencies]
+[target.powerpc-unknown-netbsd.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
-[target.mipsel-unknown-none.dependencies]
+[target.mipsel-unknown-linux-uclibc.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
 ### END HAKARI SECTION

--- a/fixtures/large/hakari/metadata_libra_f0091a4-7.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['powerpc-unknown-linux-musl']
+# platforms = ['powerpc-unknown-linux-gnuspe']
 # [[traversal-excludes.ids]]
 # name = 'build_const'
 # version = '0.2.1'
@@ -789,7 +789,7 @@ yamux = { version = "0.4", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
-[target.powerpc-unknown-linux-musl.dependencies]
+[target.powerpc-unknown-linux-gnuspe.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
 crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
@@ -812,7 +812,7 @@ unicase = { version = "2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
-[target.powerpc-unknown-linux-musl.build-dependencies]
+[target.powerpc-unknown-linux-gnuspe.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
 crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }

--- a/fixtures/large/summaries/metadata_libra-0.toml
+++ b/fixtures/large/summaries/metadata_libra-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-linux-gnux32'
+triple = 'x86_64-unknown-linux-musl'
 target-features = ['xsaves']
 flags = ['foo']
 

--- a/fixtures/large/summaries/metadata_libra-1.toml
+++ b/fixtures/large/summaries/metadata_libra-1.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'i686-unknown-openbsd'
+triple = 'i686-unknown-linux-musl'
 target-features = 'unknown'
 
 [metadata.target-platform]

--- a/fixtures/large/summaries/metadata_libra-2.toml
+++ b/fixtures/large/summaries/metadata_libra-2.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv32i-unknown-none-elf'
+triple = 'riscv32gc-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['foo']
 
@@ -2134,6 +2134,13 @@ status = 'transitive'
 features = ['default', 'with-deprecated']
 
 [[host-package]]
+name = 'mio-uds'
+version = '0.6.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'multimap'
 version = '0.4.0'
 crates-io = true
@@ -2150,6 +2157,13 @@ features = ['default', 'duration']
 [[host-package]]
 name = 'nibble_vec'
 version = '0.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nix'
+version = '0.14.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2981,6 +2995,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'tokio-signal'
+version = '0.2.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'tokio-sync'
 version = '0.1.6'
 crates-io = true
@@ -3018,6 +3039,13 @@ features = ['async-traits']
 [[host-package]]
 name = 'tokio-udp'
 version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-uds'
+version = '0.2.5'
 crates-io = true
 status = 'transitive'
 features = []
@@ -3128,6 +3156,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'utf8parse'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'uuid'
 version = '0.7.4'
 crates-io = true
@@ -3147,6 +3182,13 @@ version = '0.1.5'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[host-package]]
 name = 'wait-timeout'

--- a/fixtures/large/summaries/metadata_libra-3.toml
+++ b/fixtures/large/summaries/metadata_libra-3.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'mipsisa64r6-unknown-linux-gnuabi64'
+triple = 'mipsisa32r6-unknown-linux-gnu'
 target-features = []
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'powerpc-unknown-netbsd'
+triple = 'powerpc-unknown-linux-gnuspe'
 target-features = 'unknown'
 flags = ['abc']
 

--- a/fixtures/large/summaries/metadata_libra-4.toml
+++ b/fixtures/large/summaries/metadata_libra-4.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'armv7a-none-eabi'
+triple = 'armv7-wrs-vxworks-eabihf'
 target-features = 'unknown'
 flags = ['bar']
 
 [metadata.target-platform]
-triple = 'mipsisa32r6el-unknown-linux-gnu'
+triple = 'mipsisa32r6-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/large/summaries/metadata_libra-6.toml
+++ b/fixtures/large/summaries/metadata_libra-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'wasm32-wasi'
+triple = 'wasm32-unknown-unknown'
 target-features = 'all'
 flags = ['abc', 'cargo_web']
 [[metadata.omitted-packages.ids]]
@@ -1898,13 +1898,6 @@ version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[target-package]]
-name = 'wasi'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default']
 
 [[host-package]]
 name = 'libra-crypto-derive'

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-1.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-1.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'thumbv7neon-unknown-linux-musleabihf'
+triple = 'thumbv7neon-linux-androideabi'
 target-features = ['bmi2', 'rdrand', 'sse4.1']
 flags = ['bar', 'test-flag']
 
 [metadata.target-platform]
-triple = 'thumbv7a-pc-windows-msvc'
+triple = 'thumbv4t-none-eabi'
 target-features = 'unknown'
 flags = ['foo', 'test-flag']
 [[metadata.omitted-packages.ids]]
@@ -427,6 +427,13 @@ version = '0.7.10'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
+
+[[target-package]]
+name = 'ansi_term'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'arrayref'
@@ -1096,20 +1103,6 @@ features = []
 [[target-package]]
 name = 'wait-timeout'
 version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'ioapiset', 'memoryapi', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntsecapi', 'processenv', 'profileapi', 'std', 'synchapi', 'sysinfoapi', 'threadpoollegacyapiset', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winsock2', 'ws2def', 'ws2ipdef', 'ws2tcpip']
-
-[[target-package]]
-name = 'winapi-util'
-version = '0.1.3'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-2.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-2.toml
@@ -11,7 +11,7 @@ triple = 'armv4t-unknown-linux-gnueabi'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'x86_64-apple-tvos'
+triple = 'x86_64-apple-ios-macabi'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'libra-json-rpc'

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-7.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-7.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'arm-unknown-linux-gnueabi'
+triple = 'arm-linux-androideabi'
 target-features = ['avx2', 'fma', 'rdrand', 'sha', 'sse2', 'ssse3', 'xsave']
 [[metadata.omitted-packages.ids]]
 name = 'rustls'

--- a/fixtures/large/summaries/metadata_libra_f0091a4-1.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-1.toml
@@ -12,7 +12,7 @@ target-features = ['avx', 'sse3']
 flags = ['abc', 'test-flag']
 
 [metadata.target-platform]
-triple = 'sparc-unknown-linux-gnu'
+triple = 'riscv64imac-unknown-none-elf'
 target-features = 'unknown'
 flags = ['bar', 'test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/large/summaries/metadata_libra_f0091a4-2.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-2.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mipsel-unknown-linux-uclibc'
+triple = 'mipsel-unknown-linux-musl'
 target-features = 'unknown'
 flags = ['abc']
 

--- a/fixtures/large/summaries/metadata_libra_f0091a4-3.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-3.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i686-unknown-haiku'
+triple = 'i686-unknown-freebsd'
 target-features = 'unknown'
 
 [metadata.target-platform]

--- a/fixtures/large/summaries/metadata_libra_f0091a4-6.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv7-unknown-freebsd'
+triple = 'armv7-linux-androideabi'
 target-features = 'unknown'
 flags = ['cargo_web']
 
@@ -2033,8 +2033,22 @@ status = 'transitive'
 features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'compat', 'default', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'futures_01', 'io', 'io-compat', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'sink', 'slab', 'std', 'tokio-io']
 
 [[host-package]]
+name = 'gcc'
+version = '0.3.55'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'generic-array'
 version = '0.12.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'get_if_addrs-sys'
+version = '0.1.1'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra_f0091a4-7.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-7.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'sparc64-unknown-linux-gnu'
+triple = 's390x-unknown-linux-musl'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/hakari/metadata1-0.toml
+++ b/fixtures/small/hakari/metadata1-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['sparc64-unknown-linux-gnu', 'bpfeb-unknown-none']
+# platforms = ['s390x-unknown-linux-gnu', 'asmjs-unknown-emscripten']
 # [[traversal-excludes.ids]]
 # name = 'linked-hash-map'
 # version = '0.5.2'

--- a/fixtures/small/hakari/metadata1-1.toml
+++ b/fixtures/small/hakari/metadata1-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['x86_64-uwp-windows-msvc', 'aarch64-pc-windows-msvc']
+# platforms = ['x86_64-uwp-windows-msvc', 'aarch64-linux-android']
 # [[traversal-excludes.ids]]
 # name = 'quote'
 # version = '1.0.2'

--- a/fixtures/small/hakari/metadata1-2.toml
+++ b/fixtures/small/hakari/metadata1-2.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['aarch64_be-unknown-linux-gnu']
+# platforms = ['aarch64-wrs-vxworks']
 # [[traversal-excludes.ids]]
 # name = 'regex'
 # version = '1.3.1'

--- a/fixtures/small/hakari/metadata1-3.toml
+++ b/fixtures/small/hakari/metadata1-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['x86_64-unknown-freebsd', 'i686-unknown-haiku', 'armv7s-apple-ios']
+# platforms = ['x86_64-unknown-freebsd', 'i686-unknown-freebsd', 'armv7a-none-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'bitflags'
 # version = '1.1.0'
@@ -51,9 +51,6 @@ quote = { path = "/fakepath/testcrate/../quote", features = ["proc-macro"] }
 syn = { version = "1", features = ["clone-impls", "derive", "fold", "full", "parsing", "printing", "proc-macro", "quote"] }
 unicode-xid = { version = "0.2" }
 version_check = { version = "0.9", default-features = false }
-
-[target.armv7s-apple-ios.dependencies]
-mach = { version = "0.2", features = ["deprecated", "use_std"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata1-5.toml
+++ b/fixtures/small/hakari/metadata1-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['armv7a-none-eabi', 'x86_64-unknown-dragonfly', 'wasm64-unknown-unknown']
+# platforms = ['armv7-unknown-netbsd-eabihf', 'x86_64-unknown-dragonfly', 'wasm32-wasi']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata2-1.toml
+++ b/fixtures/small/hakari/metadata2-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['aarch64-apple-ios-sim', 'armv7a-none-eabi']
+# platforms = ['aarch64-apple-ios-sim', 'armv7-wrs-vxworks-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'quote'
 # version = '1.0.2'

--- a/fixtures/small/hakari/metadata2-2.toml
+++ b/fixtures/small/hakari/metadata2-2.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['i686-unknown-freebsd', 'sparc-unknown-linux-gnu']
+# platforms = ['i686-pc-windows-gnu', 'riscv64imac-unknown-none-elf']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]
@@ -78,6 +78,12 @@ version_check = { version = "0.9", default-features = false }
 walkdir-cd6c3afff8ff167c = { package = "walkdir", path = "/Users/fakeuser/local/testworkspace/../walkdir", default-features = false }
 walkdir-f595c2ba2a3f28df = { package = "walkdir", version = "2", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
+
+[target.i686-pc-windows-gnu.dependencies]
+winapi-i686-pc-windows-gnu = { version = "0.4", default-features = false }
+
+[target.i686-pc-windows-gnu.build-dependencies]
+winapi-i686-pc-windows-gnu = { version = "0.4", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata2-3.toml
+++ b/fixtures/small/hakari/metadata2-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['aarch64_be-unknown-linux-gnu', 'mipsel-unknown-linux-uclibc', 'riscv32i-unknown-none-elf']
+# platforms = ['aarch64-wrs-vxworks', 'mipsel-unknown-linux-musl', 'riscv32gc-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'quote'
 # version = '1.0.2'

--- a/fixtures/small/hakari/metadata2-4.toml
+++ b/fixtures/small/hakari/metadata2-4.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['thumbv8m.main-none-eabi']
+# platforms = ['thumbv7neon-unknown-linux-musleabihf']
 # [[traversal-excludes.ids]]
 # name = 'same-file'
 # version = '1.0.5'

--- a/fixtures/small/hakari/metadata2-5.toml
+++ b/fixtures/small/hakari/metadata2-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['riscv64gc-unknown-linux-musl', 'x86_64-unknown-hermit']
+# platforms = ['riscv32imc-unknown-none-elf', 'x86_64-unknown-hermit']
 # [[traversal-excludes.ids]]
 # name = 'ctor'
 # version = '0.1.10'

--- a/fixtures/small/hakari/metadata2-6.toml
+++ b/fixtures/small/hakari/metadata2-6.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['aarch64-apple-ios-sim', 'i586-unknown-linux-musl', 'armv7-apple-ios']
+# platforms = ['aarch64-apple-tvos', 'i586-pc-windows-msvc', 'armv6k-nintendo-3ds']
 # [[traversal-excludes.ids]]
 # name = 'ctor'
 # version = '0.1.10'
@@ -52,6 +52,10 @@ proc-macro2 = { version = "1", features = ["proc-macro"] }
 quote = { path = "/Users/fakeuser/local/testworkspace/../quote", features = ["proc-macro"] }
 syn = { version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote"] }
 version_check = { version = "0.9", default-features = false }
+
+[target.i586-pc-windows-msvc.dependencies]
+winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "minwindef", "processenv", "std", "winbase", "wincon", "winerror", "winnt"] }
+winapi-util = { version = "0.1", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata2-7.toml
+++ b/fixtures/small/hakari/metadata2-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['i686-unknown-freebsd', 'armv6-unknown-netbsd-eabihf']
+# platforms = ['i686-pc-windows-gnu', 'armv6k-nintendo-3ds']
 # [[traversal-excludes.ids]]
 # name = 'ctor'
 # version = '0.1.10'
@@ -79,6 +79,9 @@ proc-macro2 = { version = "1", features = ["proc-macro"] }
 quote = { path = "/Users/fakeuser/local/testworkspace/../quote", features = ["proc-macro"] }
 unicode-xid = { version = "0.2" }
 version_check = { version = "0.9", default-features = false }
+
+[target.i686-pc-windows-gnu.dependencies]
+winapi = { version = "0.3", default-features = false, features = ["std", "winnt"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_alternate_registries-0.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['bpfel-unknown-none', 'riscv32i-unknown-none-elf', 'powerpc64-wrs-vxworks']
+# platforms = ['asmjs-unknown-emscripten', 'riscv32gc-unknown-linux-gnu', 'powerpc64-unknown-linux-musl']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_alternate_registries-1.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['i686-uwp-windows-msvc', 'armebv7r-none-eabi']
+# platforms = ['i686-uwp-windows-gnu', 'armebv7r-none-eabi']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_alternate_registries-3.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['powerpc64-unknown-linux-gnu']
+# platforms = ['powerpc64-unknown-freebsd']
 # [[traversal-excludes.ids]]
 # name = 'proc-macro2'
 # version = '1.0.29'

--- a/fixtures/small/hakari/metadata_alternate_registries-5.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['powerpc64-unknown-linux-musl']
+# platforms = ['powerpc64-unknown-freebsd']
 # [[traversal-excludes.ids]]
 # name = 'serde_derive'
 # version = '1.0.130'

--- a/fixtures/small/hakari/metadata_build_targets1-3.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['thumbv8m.base-none-eabi']
+# platforms = ['thumbv7neon-unknown-linux-musleabihf']
 # [[traversal-excludes.ids]]
 # name = 'testcrate'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_build_targets1-4.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-4.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['aarch64-unknown-freebsd']
+# platforms = ['aarch64-pc-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'testcrate'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_build_targets1-6.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-6.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['i686-linux-android', 'aarch64-unknown-redox']
+# platforms = ['i586-unknown-linux-musl', 'aarch64-unknown-redox']
 # [[traversal-excludes.ids]]
 # name = 'testcrate'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_build_targets1-7.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['riscv64gc-unknown-linux-musl', 'mips64el-unknown-linux-gnuabi64', 'thumbv7em-none-eabihf']
+# platforms = ['riscv32imc-esp-espidf', 'mips64-unknown-linux-gnuabi64', 'thumbv7em-none-eabi']
 # [[traversal-excludes.ids]]
 # name = 'testcrate'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-0.toml
+++ b/fixtures/small/hakari/metadata_builddep-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['powerpc-wrs-vxworks-spe', 'nvptx64-nvidia-cuda', 'i686-uwp-windows-gnu']
+# platforms = ['powerpc-unknown-openbsd', 'msp430-none-elf', 'i686-unknown-uefi']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-1.toml
+++ b/fixtures/small/hakari/metadata_builddep-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['x86_64-apple-darwin', 'armv5te-unknown-linux-uclibceabi', 'sparc64-unknown-linux-gnu']
+# platforms = ['wasm64-unknown-unknown', 'armv5te-unknown-linux-uclibceabi', 's390x-unknown-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-3.toml
+++ b/fixtures/small/hakari/metadata_builddep-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['i686-unknown-netbsd', 'sparc64-unknown-linux-gnu']
+# platforms = ['i686-unknown-linux-musl', 's390x-unknown-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-4.toml
+++ b/fixtures/small/hakari/metadata_builddep-4.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['powerpc64le-unknown-linux-musl', 'i686-uwp-windows-msvc']
+# platforms = ['powerpc64le-unknown-freebsd', 'i686-uwp-windows-gnu']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-5.toml
+++ b/fixtures/small/hakari/metadata_builddep-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['wasm64-unknown-unknown', 'thumbv7neon-unknown-linux-musleabihf', 'armv7r-none-eabihf']
+# platforms = ['wasm32-wasi', 'thumbv7neon-linux-androideabi', 'armv7a-none-eabi']
 # [[traversal-excludes.ids]]
 # name = 'main'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-6.toml
+++ b/fixtures/small/hakari/metadata_builddep-6.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['arm-linux-androideabi', 'riscv32imc-unknown-none-elf', 'armv7r-none-eabi']
+# platforms = ['arm-linux-androideabi', 'riscv32i-unknown-none-elf', 'armv7a-kmc-solid_asp3-eabihf']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_builddep-7.toml
+++ b/fixtures/small/hakari/metadata_builddep-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['thumbv8m.base-none-eabi', 'riscv64imac-unknown-none-elf', 'aarch64-unknown-freebsd']
+# platforms = ['thumbv7neon-unknown-linux-gnueabihf', 'riscv64gc-unknown-linux-musl', 'aarch64-pc-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle1-0.toml
+++ b/fixtures/small/hakari/metadata_cycle1-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['wasm32-wasi', 'x86_64-fortanix-unknown-sgx']
+# platforms = ['wasm32-unknown-unknown', 'x86_64-apple-tvos']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle1-1.toml
+++ b/fixtures/small/hakari/metadata_cycle1-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['sparc64-unknown-openbsd', 'x86_64-apple-tvos', 'mipsel-unknown-linux-gnu']
+# platforms = ['sparc-unknown-linux-gnu', 'x86_64-apple-tvos', 'mips64el-unknown-linux-muslabi64']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle1-5.toml
+++ b/fixtures/small/hakari/metadata_cycle1-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['thumbv4t-none-eabi', 'thumbv8m.base-none-eabi', 'x86_64-unknown-none-hermitkernel']
+# platforms = ['sparc64-unknown-openbsd', 'thumbv7neon-unknown-linux-musleabihf', 'x86_64-unknown-none-hermitkernel']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle1-7.toml
+++ b/fixtures/small/hakari/metadata_cycle1-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['armv7a-none-eabi']
+# platforms = ['armv7-wrs-vxworks-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-0.toml
+++ b/fixtures/small/hakari/metadata_cycle2-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['aarch64-apple-ios-macabi', 'x86_64-unknown-freebsd']
+# platforms = ['aarch64-apple-ios-macabi', 'x86_64-unknown-dragonfly']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-2.toml
+++ b/fixtures/small/hakari/metadata_cycle2-2.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['msp430-none-elf', 'aarch64-apple-tvos', 'wasm32-wasi']
+# platforms = ['mipsisa64r6el-unknown-linux-gnuabi64', 'aarch64-apple-tvos', 'wasm32-unknown-unknown']
 # [[traversal-excludes.ids]]
 # name = 'lower-b'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-3.toml
+++ b/fixtures/small/hakari/metadata_cycle2-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['powerpc-wrs-vxworks']
+# platforms = ['powerpc-unknown-netbsd']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-4.toml
+++ b/fixtures/small/hakari/metadata_cycle2-4.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['thumbv7neon-linux-androideabi', 'x86_64-unknown-freebsd']
+# platforms = ['thumbv7m-none-eabi', 'x86_64-unknown-freebsd']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_cycle2-6.toml
+++ b/fixtures/small/hakari/metadata_cycle2-6.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['bpfeb-unknown-none', 'thumbv7a-uwp-windows-msvc']
+# platforms = ['armv7s-apple-ios', 'thumbv6m-none-eabi']
 # [[traversal-excludes.ids]]
 # name = 'lower-b'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-7.toml
+++ b/fixtures/small/hakari/metadata_cycle2-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['i686-uwp-windows-gnu']
+# platforms = ['i686-unknown-openbsd']
 # [[traversal-excludes.ids]]
 # name = 'upper-a'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-0.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['armv7-unknown-linux-gnueabi', 'riscv32imac-unknown-none-elf', 'x86_64-apple-tvos']
+# platforms = ['armv7-unknown-linux-gnueabi', 'riscv32gc-unknown-linux-musl', 'x86_64-apple-tvos']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-helper'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-1.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['x86_64-linux-android', 'mips64el-unknown-linux-gnuabi64']
+# platforms = ['x86_64-linux-android', 'mips64-unknown-linux-gnuabi64']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-3.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['x86_64-unknown-none-hermitkernel', 'armv7-apple-ios']
+# platforms = ['x86_64-unknown-none', 'armv6k-nintendo-3ds']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_dups-0.toml
+++ b/fixtures/small/hakari/metadata_dups-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['mipsisa64r6el-unknown-linux-gnuabi64', 'i686-wrs-vxworks']
+# platforms = ['mipsisa64r6-unknown-linux-gnuabi64', 'i686-uwp-windows-gnu']
 # [[traversal-excludes.ids]]
 # name = 'bytes'
 # version = '0.3.0'

--- a/fixtures/small/hakari/metadata_dups-1.toml
+++ b/fixtures/small/hakari/metadata_dups-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['i686-apple-darwin', 'riscv64gc-unknown-none-elf', 'armv5te-unknown-linux-uclibceabi']
+# platforms = ['i586-unknown-linux-gnu', 'riscv32imc-unknown-none-elf', 'armv5te-unknown-linux-uclibceabi']
 # [[traversal-excludes.ids]]
 # name = 'lazy_static'
 # version = '0.2.11'

--- a/fixtures/small/hakari/metadata_dups-3.toml
+++ b/fixtures/small/hakari/metadata_dups-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['armv5te-unknown-linux-musleabi']
+# platforms = ['armv5te-unknown-linux-uclibceabi']
 # [[traversal-excludes.ids]]
 # name = 'bytes'
 # version = '0.3.0'

--- a/fixtures/small/hakari/metadata_dups-5.toml
+++ b/fixtures/small/hakari/metadata_dups-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['thumbv7m-none-eabi']
+# platforms = ['thumbv7em-none-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'bytes'
 # version = '0.5.4'

--- a/fixtures/small/hakari/metadata_dups-6.toml
+++ b/fixtures/small/hakari/metadata_dups-6.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['armv7-unknown-linux-musleabihf', 'x86_64-pc-solaris']
+# platforms = ['armv7-unknown-linux-musleabi', 'x86_64-linux-android']
 # [[traversal-excludes.ids]]
 # name = 'lazy_static'
 # version = '1.4.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-0.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-0.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['aarch64_be-unknown-linux-gnu', 'x86_64-wrs-vxworks', 'powerpc64-unknown-freebsd']
+# platforms = ['aarch64_be-unknown-linux-gnu', 'x86_64-wrs-vxworks', 'powerpc-wrs-vxworks-spe']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_proc_macro1-1.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['x86_64-fuchsia', 'avr-unknown-gnu-atmega328', 'armv7a-none-eabihf']
+# platforms = ['x86_64-fuchsia', 'armv7r-none-eabihf', 'armv7a-kmc-solid_asp3-eabi']
 # [[traversal-excludes.ids]]
 # name = 'dev-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-2.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-2.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['mipsisa32r6el-unknown-linux-gnu', 'powerpc-wrs-vxworks']
+# platforms = ['mipsisa32r6-unknown-linux-gnu', 'powerpc-unknown-netbsd']
 # [[traversal-excludes.ids]]
 # name = 'build-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-3.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-3.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['armebv7r-none-eabi', 'armv7r-none-eabi', 'aarch64-uwp-windows-msvc']
+# platforms = ['armebv7r-none-eabi', 'armv7a-kmc-solid_asp3-eabihf', 'aarch64-unknown-uefi']
 # [[traversal-excludes.ids]]
 # name = 'build-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-4.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-4.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['aarch64-apple-ios-macabi', 'mips64el-unknown-linux-muslabi64', 'mipsel-sony-psp']
+# platforms = ['aarch64-apple-ios-sim', 'mips64-unknown-linux-muslabi64', 'mips64el-unknown-linux-gnuabi64']
 # [[traversal-excludes.ids]]
 # name = 'build-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-5.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['i686-pc-windows-msvc', 'powerpc64-unknown-linux-musl']
+# platforms = ['i686-linux-android', 'powerpc64-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'dev-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-7.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['x86_64-unknown-illumos', 'armv7-unknown-linux-musleabi']
+# platforms = ['x86_64-unknown-l4re-uclibc', 'armv7-unknown-linux-musleabi']
 # [[traversal-excludes.ids]]
 # name = 'build-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_targets1-1.toml
+++ b/fixtures/small/hakari/metadata_targets1-1.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['armv7r-none-eabihf', 'mipsel-unknown-linux-musl', 'i686-unknown-linux-gnu']
+# platforms = ['armv7a-none-eabihf', 'mipsel-sony-psp', 'i686-unknown-freebsd']
 # [[traversal-excludes.ids]]
 # name = 'serde'
 # version = '1.0.105'
@@ -19,13 +19,13 @@ bytes = { version = "0.5", features = ["serde", "std"] }
 dep-a = { path = "/Users/fakeuser/local/testcrates/testcrate-targets/../dep-a", default-features = false, features = ["bar", "baz", "foo", "quux"] }
 lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false }
 
-[target.armv7r-none-eabihf.dependencies]
+[target.armv7a-none-eabihf.dependencies]
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 
-[target.mipsel-unknown-linux-musl.dependencies]
+[target.mipsel-sony-psp.dependencies]
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 
-[target.i686-unknown-linux-gnu.dependencies]
+[target.i686-unknown-freebsd.dependencies]
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 
 ### END HAKARI SECTION

--- a/fixtures/small/hakari/metadata_targets1-2.toml
+++ b/fixtures/small/hakari/metadata_targets1-2.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['i686-unknown-linux-musl', 'armv5te-unknown-linux-gnueabi', 'powerpc64-unknown-linux-gnu']
+# platforms = ['i686-unknown-haiku', 'armv5te-unknown-linux-gnueabi', 'powerpc-wrs-vxworks-spe']
 # [[traversal-excludes.ids]]
 # name = 'dep-a'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_targets1-5.toml
+++ b/fixtures/small/hakari/metadata_targets1-5.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '2'
-# platforms = ['s390x-unknown-linux-gnu', 'wasm32-unknown-unknown', 'mips64-unknown-linux-muslabi64']
+# platforms = ['riscv64gc-unknown-none-elf', 'wasm32-unknown-emscripten', 'mips-unknown-linux-uclibc']
 # [[traversal-excludes.ids]]
 # name = 'dep-a'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_targets1-7.toml
+++ b/fixtures/small/hakari/metadata_targets1-7.toml
@@ -6,7 +6,7 @@
 # unify-target-host = 'none'
 # output-single-feature = true
 # dep-format-version = '2'
-# platforms = ['aarch64_be-unknown-linux-gnu_ilp32']
+# platforms = ['aarch64_be-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'testcrate-targets'
 # version = '0.1.0'

--- a/fixtures/small/summaries/metadata1-2.toml
+++ b/fixtures/small/summaries/metadata1-2.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'sparc64-unknown-netbsd'
+triple = 'sparc-unknown-linux-gnu'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata1-3.toml
+++ b/fixtures/small/summaries/metadata1-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'thumbv7a-uwp-windows-msvc'
+triple = 'thumbv6m-none-eabi'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'serde'
@@ -111,20 +111,6 @@ features = []
 name = 'walkdir'
 version = '2.2.9'
 source = 'git+https://github.com/BurntSushi/walkdir?tag=2.2.9#7c7013259eb9db400b3e5c7bc60330ca08068826'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'minwindef', 'processenv', 'std', 'winbase', 'wincon', 'winerror', 'winnt']
-
-[[target-package]]
-name = 'winapi-util'
-version = '0.1.2'
-crates-io = true
 status = 'transitive'
 features = []
 

--- a/fixtures/small/summaries/metadata1-4.toml
+++ b/fixtures/small/summaries/metadata1-4.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'wasm32-unknown-unknown'
+triple = 'wasm32-unknown-emscripten'
 target-features = ['sse', 'sse3', 'xsaves']
 [[metadata.omitted-packages.ids]]
 name = 'testcrate'

--- a/fixtures/small/summaries/metadata1-5.toml
+++ b/fixtures/small/summaries/metadata1-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'i686-uwp-windows-gnu'
+triple = 'i686-unknown-openbsd'
 target-features = 'all'
 flags = ['bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata1-6.toml
+++ b/fixtures/small/summaries/metadata1-6.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i686-pc-windows-msvc'
+triple = 'i686-linux-android'
 target-features = 'all'
 flags = ['abc']
 
 [metadata.target-platform]
-triple = 'x86_64-fortanix-unknown-sgx'
+triple = 'x86_64-apple-tvos'
 target-features = ['avx2', 'sse2', 'ssse3', 'xsave']
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata1-7.toml
+++ b/fixtures/small/summaries/metadata1-7.toml
@@ -12,7 +12,7 @@ target-features = 'unknown'
 flags = ['flag-test', 'foo']
 
 [metadata.target-platform]
-triple = 'thumbv6m-none-eabi'
+triple = 'sparcv9-sun-solaris'
 target-features = 'all'
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata2-0.toml
+++ b/fixtures/small/summaries/metadata2-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'sparc-unknown-linux-gnu'
+triple = 's390x-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['abc', 'cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata2-1.toml
+++ b/fixtures/small/summaries/metadata2-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'arm-unknown-linux-gnueabihf'
+triple = 'arm-unknown-linux-gnueabi'
 target-features = 'all'
 flags = ['abc', 'cargo_web']
 

--- a/fixtures/small/summaries/metadata2-2.toml
+++ b/fixtures/small/summaries/metadata2-2.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'sparc-unknown-linux-gnu'
+triple = 'riscv64imac-unknown-none-elf'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata2-3.toml
+++ b/fixtures/small/summaries/metadata2-3.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'riscv64imac-unknown-none-elf'
+triple = 'riscv64gc-unknown-linux-musl'
 target-features = 'all'
 
 [metadata.target-platform]
-triple = 's390x-unknown-linux-musl'
+triple = 'riscv64imac-unknown-none-elf'
 target-features = ['sse4.2', 'xsaveopt', 'xsaves']
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_alternate_registries-0.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv64imac-unknown-none-elf'
+triple = 'riscv64gc-unknown-linux-gnu'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_alternate_registries-1.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-1.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv7r-none-eabihf'
+triple = 'armv7a-none-eabi'
 target-features = ['aes', 'fma', 'sha', 'sse2', 'xsavec']
 
 [metadata.target-platform]
-triple = 'mips64el-unknown-linux-muslabi64'
+triple = 'mips64-unknown-linux-muslabi64'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'quote'

--- a/fixtures/small/summaries/metadata_alternate_registries-2.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-2.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'mips-unknown-linux-uclibc'
+triple = 'mips-unknown-linux-gnu'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_alternate_registries-3.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'riscv32imac-unknown-none-elf'
+triple = 'riscv32gc-unknown-linux-musl'
 target-features = 'all'
 flags = ['cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_alternate_registries-4.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-4.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-linux-android'
+triple = 'x86_64-fuchsia'
 target-features = 'all'
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata_alternate_registries-6.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'i586-unknown-linux-musl'
+triple = 'i586-pc-windows-msvc'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'proc-macro2'

--- a/fixtures/small/summaries/metadata_alternate_registries-7.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-7.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mips64-unknown-linux-gnuabi64'
+triple = 'mips-unknown-linux-musl'
 target-features = 'all'
 flags = ['flag-test', 'foo']
 

--- a/fixtures/small/summaries/metadata_build_targets1-1.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'hexagon-unknown-linux-musl'
+triple = 'avr-unknown-gnu-atmega328'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'testcrate'

--- a/fixtures/small/summaries/metadata_build_targets1-2.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 's390x-unknown-linux-gnu'
+triple = 'riscv64gc-unknown-none-elf'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'testcrate'

--- a/fixtures/small/summaries/metadata_build_targets1-3.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'powerpc-wrs-vxworks-spe'
+triple = 'powerpc-unknown-openbsd'
 target-features = ['ssse3']
 
 [[target-package]]

--- a/fixtures/small/summaries/metadata_build_targets1-5.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-5.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'powerpc64-unknown-linux-gnu'
+triple = 'powerpc64-unknown-freebsd'
 target-features = 'all'
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata_build_targets1-6.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'powerpc64-wrs-vxworks'
+triple = 'powerpc64-unknown-linux-musl'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'testcrate'

--- a/fixtures/small/summaries/metadata_build_targets1-7.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-7.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'thumbv6m-none-eabi'
+triple = 'sparcv9-sun-solaris'
 target-features = 'all'
 flags = ['cargo_web']
 
 [metadata.target-platform]
-triple = 'mips-unknown-linux-gnu'
+triple = 'i686-wrs-vxworks'
 target-features = ['bmi1', 'sse', 'sse3', 'sse4.1', 'ssse3', 'xsavec']
 [[metadata.omitted-packages.ids]]
 name = 'testcrate'

--- a/fixtures/small/summaries/metadata_builddep-0.toml
+++ b/fixtures/small/summaries/metadata_builddep-0.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'mips-unknown-linux-musl'
+triple = 'm68k-unknown-linux-gnu'
 target-features = 'all'
 flags = ['test-flag']
 
 [metadata.target-platform]
-triple = 'thumbv8m.main-none-eabihf'
+triple = 'thumbv8m.base-none-eabi'
 target-features = 'unknown'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_builddep-2.toml
+++ b/fixtures/small/summaries/metadata_builddep-2.toml
@@ -12,7 +12,7 @@ target-features = 'unknown'
 flags = ['cargo_web', 'test-flag']
 
 [metadata.target-platform]
-triple = 'thumbv8m.main-none-eabi'
+triple = 'thumbv8m.base-none-eabi'
 target-features = 'all'
 flags = ['abc', 'flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_builddep-3.toml
+++ b/fixtures/small/summaries/metadata_builddep-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv7-apple-ios'
+triple = 'armv6k-nintendo-3ds'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'builddep'

--- a/fixtures/small/summaries/metadata_builddep-5.toml
+++ b/fixtures/small/summaries/metadata_builddep-5.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'x86_64-apple-darwin'
+triple = 'wasm64-unknown-unknown'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_cycle1-0.toml
+++ b/fixtures/small/summaries/metadata_cycle1-0.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'x86_64-apple-ios-macabi'
+triple = 'x86_64-apple-ios'
 target-features = 'unknown'
 flags = ['cargo_web']
 
 [metadata.target-platform]
-triple = 'riscv32imc-unknown-none-elf'
+triple = 'riscv32i-unknown-none-elf'
 target-features = []
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle1-3.toml
+++ b/fixtures/small/summaries/metadata_cycle1-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'bpfeb-unknown-none'
+triple = 'asmjs-unknown-emscripten'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'testcycles-base'

--- a/fixtures/small/summaries/metadata_cycle1-5.toml
+++ b/fixtures/small/summaries/metadata_cycle1-5.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mipsel-unknown-linux-musl'
+triple = 'mipsel-unknown-linux-gnu'
 target-features = 'unknown'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_cycle1-6.toml
+++ b/fixtures/small/summaries/metadata_cycle1-6.toml
@@ -12,7 +12,7 @@ target-features = 'all'
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-hermit'
+triple = 'aarch64-unknown-freebsd'
 target-features = 'all'
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle1-7.toml
+++ b/fixtures/small/summaries/metadata_cycle1-7.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv32i-unknown-none-elf'
+triple = 'riscv32gc-unknown-linux-gnu'
 target-features = ['bmi1', 'sha', 'sse4.2', 'xsaveopt']
 flags = ['flag-test']
 

--- a/fixtures/small/summaries/metadata_cycle2-2.toml
+++ b/fixtures/small/summaries/metadata_cycle2-2.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-linux-musl'
+triple = 'riscv32imc-unknown-none-elf'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-none-linuxkernel'
+triple = 'x86_64-unknown-none-hermitkernel'
 target-features = ['avx', 'bmi1']
 flags = ['cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle2-3.toml
+++ b/fixtures/small/summaries/metadata_cycle2-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'x86_64-apple-darwin'
+triple = 'wasm64-unknown-unknown'
 target-features = 'unknown'
 flags = ['bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle2-5.toml
+++ b/fixtures/small/summaries/metadata_cycle2-5.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'avr-unknown-gnu-atmega328'
+triple = 'armv7r-none-eabihf'
 target-features = 'unknown'
 flags = ['bar']
 

--- a/fixtures/small/summaries/metadata_cycle2-6.toml
+++ b/fixtures/small/summaries/metadata_cycle2-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'arm-unknown-linux-musleabi'
+triple = 'arm-unknown-linux-gnueabihf'
 target-features = 'unknown'
 flags = ['bar', 'flag-test']
 

--- a/fixtures/small/summaries/metadata_cycle_features-1.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'mips64el-unknown-linux-gnuabi64'
+triple = 'mips64-unknown-linux-gnuabi64'
 target-features = 'unknown'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle_features-3.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-3.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'sparc-unknown-linux-gnu'
+triple = 's390x-unknown-linux-gnu'
 target-features = 'all'
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'i686-linux-android'
+triple = 'i586-unknown-linux-musl'
 target-features = ['bmi2', 'sse', 'sse4.1']
 flags = ['bar', 'flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle_features-5.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-5.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i686-wrs-vxworks'
+triple = 'i686-uwp-windows-msvc'
 target-features = 'all'
 flags = ['cargo_web', 'foo']
 
 [metadata.target-platform]
-triple = 'i686-unknown-freebsd'
+triple = 'i686-pc-windows-msvc'
 target-features = 'unknown'
 flags = ['cargo_web', 'foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle_features-6.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'mips64-unknown-linux-gnuabi64'
+triple = 'mips-unknown-linux-musl'
 target-features = 'unknown'
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata_cycle_features-7.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-7.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'x86_64-uwp-windows-msvc'
+triple = 'x86_64-uwp-windows-gnu'
 target-features = 'all'
 
 [metadata.target-platform]
-triple = 'armv6-unknown-netbsd-eabihf'
+triple = 'armv6k-nintendo-3ds'
 target-features = 'all'
 
 [[target-package]]

--- a/fixtures/small/summaries/metadata_dups-0.toml
+++ b/fixtures/small/summaries/metadata_dups-0.toml
@@ -12,7 +12,7 @@ target-features = 'all'
 flags = ['bar']
 
 [metadata.target-platform]
-triple = 'riscv64gc-unknown-linux-gnu'
+triple = 'riscv32imac-unknown-none-elf'
 target-features = []
 flags = ['cargo_web', 'foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_dups-3.toml
+++ b/fixtures/small/summaries/metadata_dups-3.toml
@@ -12,7 +12,7 @@ target-features = 'all'
 flags = ['test-flag']
 
 [metadata.target-platform]
-triple = 'wasm32-unknown-unknown'
+triple = 'wasm32-unknown-emscripten'
 target-features = ['avx', 'sha', 'sse', 'xsaveopt']
 flags = ['flag-test', 'foo']
 

--- a/fixtures/small/summaries/metadata_dups-4.toml
+++ b/fixtures/small/summaries/metadata_dups-4.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mips-unknown-linux-musl'
+triple = 'm68k-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['cargo_web']
 

--- a/fixtures/small/summaries/metadata_dups-5.toml
+++ b/fixtures/small/summaries/metadata_dups-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'powerpc-unknown-linux-gnuspe'
+triple = 'powerpc-unknown-freebsd'
 target-features = 'all'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_proc_macro1-0.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv32imc-unknown-none-elf'
+triple = 'riscv32i-unknown-none-elf'
 target-features = ['ssse3', 'xsaves']
 flags = ['cargo_web', 'foo']
 

--- a/fixtures/small/summaries/metadata_proc_macro1-2.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-2.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'sparc64-unknown-netbsd'
+triple = 'sparc-unknown-linux-gnu'
 target-features = ['fma', 'sse4.1']
 flags = ['flag-test']
 

--- a/fixtures/small/summaries/metadata_targets1-0.toml
+++ b/fixtures/small/summaries/metadata_targets1-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'aarch64-fuchsia'
+triple = 'aarch64-kmc-solid_asp3'
 target-features = ['fma', 'sse', 'sse3', 'sse4.2', 'xsavec', 'xsaveopt']
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_targets1-1.toml
+++ b/fixtures/small/summaries/metadata_targets1-1.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv7s-apple-ios'
+triple = 'armv7a-none-eabihf'
 target-features = 'unknown'
 flags = ['abc', 'bar']
 

--- a/fixtures/small/summaries/metadata_targets1-2.toml
+++ b/fixtures/small/summaries/metadata_targets1-2.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mipsel-unknown-linux-musl'
+triple = 'mipsel-unknown-linux-gnu'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'armv7-apple-ios'
+triple = 'armv6k-nintendo-3ds'
 target-features = 'unknown'
 flags = ['abc', 'bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_targets1-5.toml
+++ b/fixtures/small/summaries/metadata_targets1-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'bpfeb-unknown-none'
+triple = 'armv7s-apple-ios'
 target-features = []
 [[metadata.omitted-packages.ids]]
 name = 'bytes'

--- a/fixtures/small/summaries/metadata_targets1-6.toml
+++ b/fixtures/small/summaries/metadata_targets1-6.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv64imac-unknown-none-elf'
+triple = 'riscv64gc-unknown-linux-gnu'
 target-features = ['rdrand']
 flags = ['bar']
 
 [metadata.target-platform]
-triple = 'mipsel-unknown-linux-gnu'
+triple = 'mipsel-sony-psp'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'dep-a'

--- a/fixtures/small/summaries/metadata_targets1-7.toml
+++ b/fixtures/small/summaries/metadata_targets1-7.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'mipsisa64r6el-unknown-linux-gnuabi64'
+triple = 'mipsisa64r6-unknown-linux-gnuabi64'
 target-features = ['avx2', 'sse3']
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'mips64el-unknown-linux-gnuabi64'
+triple = 'mips64-unknown-linux-gnuabi64'
 target-features = 'unknown'
 
 [[metadata.features-only]]

--- a/target-spec/CHANGELOG.md
+++ b/target-spec/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+## Changed
+
+- Internal dependency version bump: `cfg-expr` updated to 0.10.0.
+
 ## [0.9.0] - 2021-10-01
 
 ## Added

--- a/target-spec/Cargo.toml
+++ b/target-spec/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-cfg-expr = { version = "0.9.0", features = ["targets"] }
+cfg-expr = { version = "0.10.0", features = ["targets"] }
 proptest = { version = "1.0.0", optional = true }
 serde = { version = "1.0.133", optional = true, features = ["derive"] }
 target-lexicon = { version = "0.12.2", features = ["std"] }


### PR DESCRIPTION
Also bump up the cargo-compare tests to 1.58 as a result.