### PR TITLE
[ci] work around bug in actions-rs/toolchain version spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           # 1.60 is the cfg-expr version
-          toolchain: 1.60
+          toolchain: 1.60.0
           override: true
       - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
       - name: Build and test


### PR DESCRIPTION
Apparently actions-rs/toolchain chokes on "1.60" and interprets it as "1.6" -- fix it to use "1.60.0".